### PR TITLE
第14章: Git LFSの.lfsconfig設定の補足説明を追加

### DIFF
--- a/src/chapters/chapter14/index.md
+++ b/src/chapters/chapter14/index.md
@@ -45,8 +45,9 @@ git commit -m "Configure Git LFS tracking"
 ```ini
 # .lfsconfig
 [lfs]
-    # GitHubのLFSエンドポイント
-    url = https://github.com/org/repo.git/info/lfs
+    # GitHubのLFSエンドポイント（GitHub Enterprise Serverまたはカスタムサーバー用）
+    # 注意: GitHub.comを使用している場合、この設定は通常不要です
+    # url = https://github.com/org/repo.git/info/lfs
     
     # 同時転送数
     concurrenttransfers = 8
@@ -68,6 +69,11 @@ git commit -m "Configure Git LFS tracking"
     smudge = git-lfs smudge -- %f
     process = git-lfs filter-process
 ```
+
+**注意事項：**
+- `url`設定はGitHub Enterprise ServerやセルフホストのGit LFSサーバーを使用する場合にのみ必要です
+- GitHub.comのパブリック/プライベートリポジトリでは、LFSエンドポイントは自動的に解決されるため設定不要です
+- カスタムLFSサーバーを使用する場合のみ、適切なエンドポイントURLを設定してください
 
 ### LFSの使用パターン
 


### PR DESCRIPTION
## Summary
- Git LFSの.lfsconfigファイルにおけるURL設定について、適切な使用場面を明確化
- GitHub.comユーザーへの誤解を防ぐための注意事項を追加

## Changes
### URL設定の明確化
- URL設定がGitHub Enterprise ServerやカスタムLFSサーバー用であることを明記
- GitHub.comでは通常不要であることを注意として追加
- 設定例をコメントアウトして意図を明確化

### 詳細説明の追加
- どの環境でURL設定が必要かを具体的に説明
- 自動解決される場合の説明を追加
- カスタムサーバー使用時の注意点を明記

## Benefits
- GitHub.comユーザーが不要な設定を行うことを防ぐ
- 適切な使用場面が明確になる
- 設定ミスによる問題を回避できる

## Test plan
- [x] 説明が技術的に正確であることを確認
- [x] 初学者にとって理解しやすいことを確認

Fixes #45

🤖 Generated with [Claude Code](https://claude.ai/code)