### PR TITLE
🔧 Fix page navigation by adding order fields

### DIFF
--- a/docs/appendices/appendix-a/index.md
+++ b/docs/appendices/appendix-a/index.md
@@ -1,5 +1,6 @@
 ---
 layout: book
+order: 19
 title: "付録A：GitHub用語集"
 ---
 

--- a/docs/appendices/appendix-b/index.md
+++ b/docs/appendices/appendix-b/index.md
@@ -1,5 +1,6 @@
 ---
 layout: book
+order: 20
 title: "付録B：トラブルシューティングガイド"
 ---
 

--- a/docs/appendices/appendix-c/index.md
+++ b/docs/appendices/appendix-c/index.md
@@ -1,5 +1,6 @@
 ---
 layout: book
+order: 21
 title: "付録C：料金プランと機能比較表"
 ---
 

--- a/docs/appendices/appendix-d/index.md
+++ b/docs/appendices/appendix-d/index.md
@@ -1,5 +1,6 @@
 ---
 layout: book
+order: 22
 title: "付録D：AIツールのコスト計算例"
 ---
 

--- a/docs/appendices/appendix-e/index.md
+++ b/docs/appendices/appendix-e/index.md
@@ -1,5 +1,6 @@
 ---
 layout: book
+order: 23
 title: "付録E：便利なGitエイリアス集"
 ---
 

--- a/docs/appendices/appendix-f/index.md
+++ b/docs/appendices/appendix-f/index.md
@@ -1,5 +1,6 @@
 ---
 layout: book
+order: 24
 title: "付録F：推奨VS Code拡張機能"
 ---
 

--- a/docs/appendices/appendix-g/index.md
+++ b/docs/appendices/appendix-g/index.md
@@ -1,5 +1,6 @@
 ---
 layout: book
+order: 25
 title: "第16章：コンプライアンスとガバナンス"
 ---
 

--- a/docs/chapters/chapter01/index.md
+++ b/docs/chapters/chapter01/index.md
@@ -1,5 +1,6 @@
 ---
 layout: book
+order: 2
 title: "第1章：GitとGitHubの基本概念"
 ---
 

--- a/docs/chapters/chapter02/index.md
+++ b/docs/chapters/chapter02/index.md
@@ -1,5 +1,6 @@
 ---
 layout: book
+order: 3
 title: "第2章：AI時代のGitHub協働基礎"
 ---
 

--- a/docs/chapters/chapter03/index.md
+++ b/docs/chapters/chapter03/index.md
@@ -1,5 +1,6 @@
 ---
 layout: book
+order: 4
 title: "第3章：必須コマンドとAI活用"
 ---
 

--- a/docs/chapters/chapter04/index.md
+++ b/docs/chapters/chapter04/index.md
@@ -1,5 +1,6 @@
 ---
 layout: book
+order: 5
 title: "第4章：GitHubでの協働作業入門"
 ---
 

--- a/docs/chapters/chapter05/index.md
+++ b/docs/chapters/chapter05/index.md
@@ -1,5 +1,6 @@
 ---
 layout: book
+order: 6
 title: "第5章：GitHubアカウントとリポジトリ管理"
 ---
 

--- a/docs/chapters/chapter06/index.md
+++ b/docs/chapters/chapter06/index.md
@@ -1,5 +1,6 @@
 ---
 layout: book
+order: 7
 title: "第6章：GitHub Copilotの高度な活用"
 ---
 

--- a/docs/chapters/chapter07/index.md
+++ b/docs/chapters/chapter07/index.md
@@ -1,5 +1,6 @@
 ---
 layout: book
+order: 8
 title: "第7章：AI支援によるコードレビュー実践"
 ---
 

--- a/docs/chapters/chapter08/index.md
+++ b/docs/chapters/chapter08/index.md
@@ -1,5 +1,6 @@
 ---
 layout: book
+order: 9
 title: "第8章：GitHub Advanced SecurityとAI統合"
 ---
 

--- a/docs/chapters/chapter09/index.md
+++ b/docs/chapters/chapter09/index.md
@@ -1,5 +1,6 @@
 ---
 layout: book
+order: 10
 title: "第9章：アクセス権限の体系"
 ---
 

--- a/docs/chapters/chapter10/index.md
+++ b/docs/chapters/chapter10/index.md
@@ -1,5 +1,6 @@
 ---
 layout: book
+order: 11
 title: "第10章：組織管理とチーム運用"
 ---
 

--- a/docs/chapters/chapter11/index.md
+++ b/docs/chapters/chapter11/index.md
@@ -1,5 +1,6 @@
 ---
 layout: book
+order: 12
 title: "第11章：セキュリティ実践"
 ---
 

--- a/docs/chapters/chapter12/index.md
+++ b/docs/chapters/chapter12/index.md
@@ -1,5 +1,6 @@
 ---
 layout: book
+order: 13
 title: "第12章：実践的なワークフロー設計"
 ---
 

--- a/docs/chapters/chapter13/index.md
+++ b/docs/chapters/chapter13/index.md
@@ -1,5 +1,6 @@
 ---
 layout: book
+order: 14
 title: "第13章：CI/CDパイプライン構築"
 ---
 

--- a/docs/chapters/chapter14/index.md
+++ b/docs/chapters/chapter14/index.md
@@ -1,5 +1,6 @@
 ---
 layout: book
+order: 15
 title: "第14章：大規模データとモデルの管理"
 ---
 

--- a/docs/chapters/chapter15/index.md
+++ b/docs/chapters/chapter15/index.md
@@ -1,5 +1,6 @@
 ---
 layout: book
+order: 16
 title: "第15章：GitHub Pagesでのプロジェクト公開"
 ---
 

--- a/docs/chapters/chapter16/index.md
+++ b/docs/chapters/chapter16/index.md
@@ -1,5 +1,6 @@
 ---
 layout: book
+order: 17
 title: "第16章：外部協力者との連携"
 ---
 

--- a/docs/chapters/chapter17/index.md
+++ b/docs/chapters/chapter17/index.md
@@ -1,5 +1,6 @@
 ---
 layout: book
+order: 18
 title: "第17章：コンプライアンスとガバナンス"
 ---
 


### PR DESCRIPTION
## 🎯 問題

github-workflow-book の各章ページで「前へ」「次へ」のナビゲーションリンクが表示されない問題がありました。

## 🔍 原因

 は正しく実装されていましたが、各章の front matter に  フィールドが設定されていないため、ナビゲーションロジックが動作していませんでした。

## ✅ 修正内容

### Front Matter に order フィールドを追加
- **Index ページ**:  (既存)
- **第1-17章**:  を追加
- **付録A-G**:  を追加

### 論理的な読書順序を確保
```
index (1) → 第1章 (2) → 第2章 (3) → ... → 第17章 (18) → 付録A (19) → ... → 付録G (25)
```

## 🎉 修正後の動作

- ✅ 各章の下部に「前へ」「次へ」ナビゲーションが表示
- ✅ 論理的な順序で章間移動が可能
- ✅ レスポンシブデザインでモバイル対応
- ✅ ホバーエフェクト付きの美しいUIコンポーネント

## 🧪 検証項目

- [ ] 第1章で「次へ」のみ表示（前へなし）
- [ ] 中間章で「前へ」「次へ」両方表示  
- [ ] 最終付録で「前へ」のみ表示（次へなし）
- [ ] 各ナビゲーションリンクが正しいページに遷移
- [ ] モバイルでの表示・動作確認

## 📝 技術詳細

page-navigation.html の動作メカニズム:
```liquid
{% assign all_pages = site.pages | where: "layout", "book" | where_exp: "page", "page.order" | sort: 'order' %}
```

この行で  フィールドを持つページのみを取得し、order値でソートしてナビゲーション順序を決定しています。

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>