### PR TITLE
Fix GitHub link display error in header

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -20,8 +20,7 @@ defaults:
 #   - jekyll-feed
 
 # Repository information for edit links
-repository:
-  github: "itdojp/github-workflow-book"
+repository: "https://github.com/itdojp/github-workflow-book"
 
 exclude:
   - node_modules/


### PR DESCRIPTION
## 問題の修正 🔧

### GitHub リンク表示エラー
- **問題**: ダークモード切替ボタンの横に `"itdojp/github-workflow-book"}" class="github-link" target="_blank" rel="noopener" aria-label="View on GitHub">` という文字列が表示される
- **原因**: `_config.yml`でのリポジトリ設定が `repository.github` となっていたが、レイアウトファイルでは `site.repository` として参照していた
- **解決**: `_config.yml`の設定を `repository: "https://github.com/itdojp/github-workflow-book"` に統一

## 変更内容

### _config.yml
```diff
- # Repository information for edit links
- repository:
-   github: "itdojp/github-workflow-book"
+ # Repository information for edit links
+ repository: "https://github.com/itdojp/github-workflow-book"
```

## 期待される結果
- GitHubリンクが正常にアイコンのみ表示される
- テキストの表示エラーが解消される
- 他のITDO書籍と同じ動作になる

## 検証方法
1. GitHub Pagesサイトにアクセス
2. ヘッダー右上のGitHubアイコンを確認
3. 不要なテキストが表示されていないことを確認
4. アイコンクリックでGitHubリポジトリに正常に遷移することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)