### PR TITLE
サイドバーに統一リソースリンクを追加

### DIFF
--- a/docs/_includes/sidebar-nav.html
+++ b/docs/_includes/sidebar-nav.html
@@ -119,6 +119,28 @@
         {% endif %}
     </div>
     {% endif %}
+
+    <!-- Additional Resources (standardized) -->
+    <div class="nav-section">
+        <h3 class="nav-section-title">📚 リソース</h3>
+        <ul class="nav-list">
+            <li class="nav-item">
+                <a href="https://github.com/itdojp/github-workflow-book" class="nav-link" target="_blank" rel="noopener">
+                    💾 GitHubリポジトリ
+                </a>
+            </li>
+            <li class="nav-item">
+                <a href="https://itdojp.github.io/it-engineer-knowledge-architecture/" class="nav-link" target="_blank" rel="noopener">
+                    📚 書籍一覧
+                </a>
+            </li>
+            <li class="nav-item">
+                <a href="https://itdo.jp" class="nav-link" target="_blank" rel="noopener">
+                    🏢 株式会社アイティードゥ
+                </a>
+            </li>
+        </ul>
+    </div>
 </div>
 
 <!-- Progress Indicator -->


### PR DESCRIPTION
Phase 8.1（ナビゲーション統一）に従い、\n\n- リソースセクションを追加（GitHubリポジトリ → 書籍一覧 → 会社）\n- すべて新規タブで開くよう  を指定\n\n参考: it-engineer-knowledge-architecture #21 / book-formatter 統一ガイド