### PR TITLE
docs: 内部リンク方針の統一（Phase #33）

### DIFF
--- a/docs/chapters/chapter05/index.md
+++ b/docs/chapters/chapter05/index.md
@@ -323,7 +323,7 @@ Full documentation is available at [https://docs.example.com](https://docs.examp
 See the [examples/](examples/) directory for more examples.
 
 ## Contributing
-Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct.
+Please read our contributing guide on GitHub: [CONTRIBUTING.md](https://github.com/itdojp/github-workflow-book/blob/main/CONTRIBUTING.md).
 
 ## License
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/docs/chapters/chapter10/index.md
+++ b/docs/chapters/chapter10/index.md
@@ -110,7 +110,7 @@ security_settings:
 - [Paper 2](link) - NeurIPS 2023
 
 ## 🤝 Contributing
-See our [Contributing Guide](CONTRIBUTING.md)
+See our [Contributing Guide](https://github.com/itdojp/github-workflow-book/blob/main/CONTRIBUTING.md)
 
 ## 📬 Contact
 - Email: contact@ai-research-lab.org

--- a/docs/chapters/chapter16/index.md
+++ b/docs/chapters/chapter16/index.md
@@ -850,7 +850,7 @@ Contributors can be nominated to become Committers based on:
 - Demonstrated understanding of the project
 
 ## Code of Conduct
-All participants must follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+All participants must follow our [Code of Conduct](https://github.com/itdojp/github-workflow-book/blob/main/CODE_OF_CONDUCT.md).
 
 ## Changes to Governance
 This governance model can be changed through the proposal process with TSC approval.


### PR DESCRIPTION
内部リンクの混在（.md参照など）を解消し、\n- GitHub上のドキュメント参照は絶対URLに\n- Jekyllページはpretty URL/Liquidを原則に（既存は保持）\n\nパイロット適用として3箇所を修正。