### PR TITLE
Stage3: 表現・スタイル改善（第4章）

### DIFF
--- a/docs/chapters/chapter04/index.md
+++ b/docs/chapters/chapter04/index.md
@@ -37,7 +37,7 @@ PyTorchを使用し、チーム開発を前提としています。
 ```
 
 **AI提案のプロジェクト構造**（各ディレクトリの役割詳細）：
-```
+```text
 image-classifier/
 ├── src/                      # メインソースコード（パッケージとして配布可能）
 │   ├── data/                 # データ処理関連
@@ -155,7 +155,7 @@ Title: [FEATURE] データ拡張機能の追加
 ```
 
 #### AI協働型バグ報告の例（第2章のテンプレート適用）
-```markdown
+````markdown
 Title: [BUG] バッチサイズ1でモデル推論時にエラー発生
 
 ## 環境情報
@@ -198,7 +198,7 @@ BatchNorm層がtraining=Trueの状態でバッチサイズ1を処理できない
 - bug
 - high-priority
 - ai-investigation
-```
+````
 
 #### Issueテンプレートの活用
 `.github/ISSUE_TEMPLATE/`にテンプレートを配置：
@@ -329,7 +329,7 @@ Fixes #5
 #### レビューコメントの例
 
 **レビュアー1のコメント：**
-```markdown
+````markdown
 Line 15 in data_loader.py:
 
 ```python
@@ -337,7 +337,7 @@ transforms.RandomCrop(224, padding=4),
 ```
 
 画像サイズが224固定になっていますが、設定可能にした方が良いのでは？
-```
+````
 
 **対応方法1：コードの修正**
 ```python
@@ -372,7 +372,7 @@ def get_train_transforms(image_size=224):
 ```
 
 **対応方法2：議論**
-```markdown
+````markdown
 確かにタスクによって適切な拡張の強度は異なりますね。
 現在は画像分類を想定していますが、将来的に他のタスクにも対応することを考えると、
 拡張の強度も設定可能にすべきでしょうか？
@@ -388,7 +388,7 @@ def get_train_transforms(image_size=224, aug_strength='medium'):
 ```
 
 どう思われますか？
-```
+````
 
 #### 修正の追加コミット
 ```bash


### PR DESCRIPTION
Issue: itdojp/it-engineer-knowledge-architecture#58

Stage3（表現・スタイル）を第4章へ展開しました（構成変更なし）。

対象:
- `docs/chapters/chapter04/index.md`

変更内容（最小差分）:
- Markdownサンプル内のネストしたコードフェンスを、````（4バッククォート）で囲む形に変更し、表示崩れを回避
- ディレクトリツリーのコードブロックに言語指定を付与（```text）

備考:
- 内容（主張・手順・用語選択）は変更していません。
