### PR TITLE
Stage3: 表現・スタイル改善（第5章）

### DIFF
--- a/docs/chapters/chapter05/index.md
+++ b/docs/chapters/chapter05/index.md
@@ -90,7 +90,7 @@ Settings → Notifications で設定：
 - **Custom**: リポジトリごとに設定
 
 推奨設定：
-```
+```text
 ✓ Participating
 ✓ @mentions
 ✓ Review requests
@@ -190,7 +190,7 @@ flowchart TD
 - **セキュリティ**: 脆弱性の非公開
 
 ### ハイブリッドアプローチ
-```
+```text
 my-ml-project/
 ├── my-ml-project-public/    # 公開可能な部分
 │   ├── src/
@@ -280,7 +280,7 @@ Protect matching branches:
 
 ### 効果的なREADMEの構造
 
-```markdown
+````markdown
 # Project Name
 
 [![Build Status](https://travis-ci.org/username/repo.svg?branch=main)](https://travis-ci.org/username/repo)
@@ -342,7 +342,7 @@ If you use this software in your research, please cite:
 ## Acknowledgments
 - Acknowledgment 1
 - Acknowledgment 2
-```
+````
 
 ### ライセンスの選択
 
@@ -374,7 +374,7 @@ If you use this software in your research, please cite:
 Settings → Template repository にチェック
 
 #### 標準構造
-```
+```text
 ml-project-template/
 ├── .github/
 │   ├── workflows/


### PR DESCRIPTION
Issue: itdojp/it-engineer-knowledge-architecture#58

Stage3（表現・スタイル）を第5章へ展開しました（構成変更なし）。

対象:
- `docs/chapters/chapter05/index.md`

変更内容（最小差分）:
- Markdownサンプル内のネストしたコードフェンスを、````（4バッククォート）で囲む形に変更し、表示崩れを回避
- 未指定のコードブロックに言語指定を付与（```text）

備考:
- 内容（主張・手順・用語選択）は変更していません。
