### PR TITLE
P0-4: rulesets/merge queue（merge_group）対応

### DIFF
--- a/docs/chapters/chapter09/index.md
+++ b/docs/chapters/chapter09/index.md
@@ -183,6 +183,33 @@ class PermissionManager:
 
 ## 9.2 AI協働を考慮したブランチ保護ルール
 
+### branch protection と rulesets の位置付け
+
+GitHub には、ブランチへの制約を表現する仕組みとして、主に次の2系統があります（利用可否や設定項目はプラン/権限で差分があるため、詳細は公式ドキュメントで要確認です）。
+
+- **branch protection rules**: ブランチパターン（例: `main`）に対して保護ルールを設定する従来の仕組み
+- **rulesets**: ブランチやタグに対してルールをまとめて適用できる仕組み（組織ポリシーとしても運用しやすい）
+
+本章では読みやすさのために「branch protection」を例に説明しますが、可能であれば rulesets を第一候補として検討してください。特に AI 協働では、次の要素を **ルール（rulesets/branch protection）+ CODEOWNERS + 必須チェック（CI）** で一体として設計すると、運用が安定します。
+
+- PR を必須にする（直 push を避ける）
+- 必須チェック（テスト/静的解析/セキュリティ）を定義する
+- CODEOWNERS による必須承認（重要領域のレビュー固定）を有効にする
+- 必要に応じて merge queue を有効化する（詳細は第13章）
+
+参考:
+- rulesets: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets
+- merge queue: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
+
+#### AI生成PRの検証レベルを「ルール + 必須チェック」で固定する（例）
+
+AI生成PRに限らず、最終的にマージされるコードの品質は「人間の善意」ではなく、ルールとチェックで担保します。rulesets/branch protection で「必須チェック（required status checks）」を要求しておけば、AI生成PRを例外扱いせずに品質ゲートへ乗せられます。
+
+例:
+- **必須チェック**: テスト、静的解析（CodeQL等）、依存関係レビュー（dependency review）など
+- **必須承認**: CODEOWNERS による重要領域（認証/暗号/決済など）の承認必須化
+- **任意の追加**: PR本文の「AI利用の開示」欄（PRテンプレ）をチェックする独自ワークフローを必須チェックにする
+
 ### 基本的な保護設定
 
 #### AI協働対応のmainブランチ保護

--- a/docs/chapters/chapter12/index.md
+++ b/docs/chapters/chapter12/index.md
@@ -159,6 +159,19 @@ gitGraph
     merge release/v1.0
 ```
 
+### rulesets と merge queue を前提にした統制
+
+大規模チームでは「ブランチ戦略」だけでなく、「マージの統制（誰が/どの条件で/どこへマージできるか）」を仕組みで固定しないと破綻しやすくなります。ここでは、ルール定義として rulesets を前提にすることを推奨します（環境により branch protection を継続するケースもあるため要確認です）。
+
+- rulesets（または branch protection）で、PR必須・必須チェック（required status checks）・必須承認（CODEOWNERS等）を定義する
+- merge queue を併用し、最終的なマージ結果に対して必須チェックが通っている状態で統合する
+- merge queue を使う場合、CI は `pull_request` だけでなく `merge_group` にも対応させる（第13章を参照）
+
+参考:
+- rulesets: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets
+- merge queue: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
+- `merge_group` イベント: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#merge_group
+
 ### 実装例
 
 #### プロジェクト初期設定スクリプト

--- a/docs/chapters/chapter13/index.md
+++ b/docs/chapters/chapter13/index.md
@@ -19,6 +19,24 @@ Copilot coding agent を使ってPRを作る場合でも、CI/CDの基本は変�
 
 ### ワークフローの基本要素
 
+### merge queue を使う場合の注意（`merge_group`）
+
+merge queue を有効にしている場合、必須チェック（required status checks）は「PRの先にある最終的なマージ結果」に対しても通る必要があります。GitHub Actions を必須チェックにしている場合、ワークフローが `pull_request` だけで起動する設計だと、merge queue 側のチェックが満たせずに詰まることがあります。
+
+そのため、必須チェックにしているワークフローは `merge_group` イベントにも対応させます。
+
+```yaml
+on:
+  pull_request:
+  merge_group:
+    types: [checks_requested]
+```
+
+参考:
+- merge queue: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
+- `merge_group` イベント: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#merge_group
+- サンプル: `examples/merge-queue-ci-example/`
+
 #### AI協働品質ゲート統合のワークフロー構造
 ```yaml
 # .github/workflows/ai-collaboration-pipeline.yml

--- a/examples/merge-queue-ci-example/.github/workflows/ci.yml
+++ b/examples/merge-queue-ci-example/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI (pull_request + merge_group)
+
+on:
+  pull_request:
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run checks
+        run: |
+          echo "Replace this step with your test/lint/security checks."
+          echo "event_name=${{ github.event_name }}"

--- a/examples/merge-queue-ci-example/README.md
+++ b/examples/merge-queue-ci-example/README.md
@@ -1,0 +1,19 @@
+# merge queue 対応のCI最小例
+
+この例は、GitHub の merge queue を有効にしたリポジトリで、必須チェック（required status checks）を満たすために GitHub Actions を `pull_request` と `merge_group` の両方で起動する構成を示します。
+
+- 参照（公式）:
+  - merge queue: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
+  - `merge_group` イベント: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#merge_group
+
+## 含まれるファイル
+
+- `.github/workflows/ci.yml`: `pull_request` と `merge_group` の双方で起動するワークフロー
+
+## 使い方（例）
+
+1. `.github/workflows/ci.yml` を対象リポジトリへコピーします。
+2. rulesets / branch protection で、このワークフローのチェック名を「必須チェック」として要求します。
+3. merge queue を有効化します。
+
+このサンプルは「トリガー設計」を示すための最小構成です。実プロジェクトでは `Run checks` を実際のテスト/静的解析/セキュリティ検査に置き換えてください。


### PR DESCRIPTION
Refs #143（P0-4）

## 変更概要
- rulesets / branch protection の位置付けを追記し、AI協働の統制（ルール + CODEOWNERS + 必須チェック）として整理
- merge queue 導入時に必要になる `merge_group`（GitHub Actions）対応を明記
- `merge_group` 対応の最小ワークフロー例を `examples/` に追加

## 変更箇所
- `docs/chapters/chapter09/index.md`: rulesetsの説明、AI生成PRを「必須チェック」で例外にしない設計例を追記
- `docs/chapters/chapter12/index.md`: rulesets/merge queue を前提にした統制のセクションを追加
- `docs/chapters/chapter13/index.md`: merge queue と `merge_group` の注意点、最小スニペット、サンプル参照を追加
- `examples/merge-queue-ci-example/`: `pull_request` + `merge_group` トリガーのCI例

## 参考（公式）
- rulesets: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets
- merge queue: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
- `merge_group`: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#merge_group
