### PR TITLE
fix(docs): resolve broken internal links

### DIFF
--- a/KINDLE_COMPLETE.md
+++ b/KINDLE_COMPLETE.md
@@ -89,7 +89,150 @@
 
 ---
 
-<!-- 以下、全章の内容を順番に統合 -->
+<!-- chapter-03-essential-commands-ai.md の内容をここに挿入 -->
+## 第3章 必須コマンドとAI活用
+
+[第3章の内容がここに入ります]
+
+---
+
+<!-- chapter-04-github-collaboration-ai.md の内容をここに挿入 -->
+## 第4章 GitHubでの協働作業入門
+
+[第4章の内容がここに入ります]
+
+---
+
+<!-- chapter-05-account-repository-ai.md の内容をここに挿入 -->
+## 第5章 GitHubアカウントとリポジトリ管理
+
+[第5章の内容がここに入ります]
+
+---
+
+<!-- chapter-06-github-copilot-advanced.md の内容をここに挿入 -->
+## 第6章 GitHub Copilotの高度な活用
+
+[第6章の内容がここに入ります]
+
+---
+
+<!-- chapter-07-ai-code-review-practice.md の内容をここに挿入 -->
+## 第7章 AI支援によるコードレビュー実践
+
+[第7章の内容がここに入ります]
+
+---
+
+<!-- chapter-08-github-advanced-security-ai.md の内容をここに挿入 -->
+## 第8章 GitHub Advanced SecurityとAI統合
+
+[第8章の内容がここに入ります]
+
+---
+
+<!-- chapter-09-access-permissions-ai.md の内容をここに挿入 -->
+## 第9章 アクセス権限の体系
+
+[第9章の内容がここに入ります]
+
+---
+
+<!-- chapter-10-organization-management-ai.md の内容をここに挿入 -->
+## 第10章 組織管理とチーム運用
+
+[第10章の内容がここに入ります]
+
+---
+
+<!-- chapter-11-security-practice-ai.md の内容をここに挿入 -->
+## 第11章 セキュリティ実践
+
+[第11章の内容がここに入ります]
+
+---
+
+<!-- chapter-12-practical-workflow.md の内容をここに挿入 -->
+## 第12章 実践的なワークフロー設計
+
+[第12章の内容がここに入ります]
+
+---
+
+<!-- chapter-13-cicd-pipeline.md の内容をここに挿入 -->
+## 第13章 CI/CDパイプライン構築
+
+[第13章の内容がここに入ります]
+
+---
+
+<!-- chapter-14-large-scale-data-model-ai.md の内容をここに挿入 -->
+## 第14章 大規模データとモデルの管理
+
+[第14章の内容がここに入ります]
+
+---
+
+<!-- chapter-15-github-pages.md の内容をここに挿入 -->
+## 第15章 GitHub Pagesでのプロジェクト公開
+
+[第15章の内容がここに入ります]
+
+---
+
+<!-- chapter-16-external-collaboration.md の内容をここに挿入 -->
+## 第16章 外部協力者との連携
+
+[第16章の内容がここに入ります]
+
+---
+
+<!-- chapter-17-compliance-governance.md の内容をここに挿入 -->
+## 第17章 コンプライアンスとガバナンス
+
+[第17章の内容がここに入ります]
+
+---
+
+<!-- appendix-a-github-glossary.md の内容をここに挿入 -->
+## 付録A GitHub用語集
+
+[付録Aの内容がここに入ります]
+
+---
+
+<!-- appendix-b-troubleshooting.md の内容をここに挿入 -->
+## 付録B トラブルシューティングガイド
+
+[付録Bの内容がここに入ります]
+
+---
+
+<!-- appendix-c-pricing-comparison.md の内容をここに挿入 -->
+## 付録C 料金プランと機能比較表
+
+[付録Cの内容がここに入ります]
+
+---
+
+<!-- appendix-d-ai-cost-calculation.md の内容をここに挿入 -->
+## 付録D AIツールのコスト計算例
+
+[付録Dの内容がここに入ります]
+
+---
+
+<!-- appendix-e-git-aliases.md の内容をここに挿入 -->
+## 付録E 便利なGitエイリアス集
+
+[付録Eの内容がここに入ります]
+
+---
+
+<!-- appendix-f-vscode-extensions.md の内容をここに挿入 -->
+## 付録F 推奨VS Code拡張機能
+
+[付録Fの内容がここに入ります]
 
 ---
 

--- a/PUBLICATION_INDEX.md
+++ b/PUBLICATION_INDEX.md
@@ -92,81 +92,81 @@
 ### 🔥 重要度別ガイド
 
 #### ⭐⭐⭐⭐⭐ 必読（全読者共通）
-- **[第2章：AI時代のGitHub協働基礎](chapter-02-ai-collaboration-fundamentals.md)**
+- **[第2章：AI時代のGitHub協働基礎](docs/chapters/chapter02/)**
   - 🎯 **本書の核心**：CLEARフレームワーク
   - 📈 即座に生産性向上を実現
   - 🛠️ 以降の全章で使用する基礎概念
 
 #### ⭐⭐⭐⭐ 高優先度（実践重視）
-- [第3章：必須コマンドとAI活用](chapter-03-essential-commands-ai.md)
-- [第4章：GitHubでの協働作業入門](chapter-04-github-collaboration-ai.md)
-- [第6章：GitHub Copilotの高度な活用](chapter-06-github-copilot-advanced.md)
-- [第7章：AI支援によるコードレビュー実践](chapter-07-ai-code-review-practice.md)
+- [第3章：必須コマンドとAI活用](docs/chapters/chapter03/)
+- [第4章：GitHubでの協働作業入門](docs/chapters/chapter04/)
+- [第6章：GitHub Copilotの高度な活用](docs/chapters/chapter06/)
+- [第7章：AI支援によるコードレビュー実践](docs/chapters/chapter07/)
 
 #### ⭐⭐⭐ 中優先度（チーム・組織向け）
-- [第9章：アクセス権限の体系](chapter-09-access-permissions-ai.md)
-- [第10章：組織管理とチーム運用](chapter-10-organization-management-ai.md)
-- [第12章：実践的なワークフロー設計](chapter-11-practical-workflow.md)
-- [第13章：CI/CDパイプライン構築](chapter-12-cicd-pipeline.md)
+- [第9章：アクセス権限の体系](docs/chapters/chapter09/)
+- [第10章：組織管理とチーム運用](docs/chapters/chapter10/)
+- [第12章：実践的なワークフロー設計](docs/chapters/chapter12/)
+- [第13章：CI/CDパイプライン構築](docs/chapters/chapter13/)
 
 ### 📖 完全章構成（クリック可能）
 
 <details>
 <summary><strong>📑 第1部：AI協働時代の基礎編</strong></summary>
 
-- [第1章：GitとGitHubの基本概念](chapter-01-git-github-basics.md)
-- [⭐ 第2章：AI時代のGitHub協働基礎](chapter-02-ai-collaboration-fundamentals.md) **【核心章】**
-- [第3章：必須コマンドとAI活用](chapter-03-essential-commands-ai.md)
-- [第4章：GitHubでの協働作業入門](chapter-04-github-collaboration-ai.md)
-- [第5章：GitHubアカウントとリポジトリ管理](chapter-05-account-repository-ai.md)
+- [第1章：GitとGitHubの基本概念](docs/chapters/chapter01/)
+- [⭐ 第2章：AI時代のGitHub協働基礎](docs/chapters/chapter02/) **【核心章】**
+- [第3章：必須コマンドとAI活用](docs/chapters/chapter03/)
+- [第4章：GitHubでの協働作業入門](docs/chapters/chapter04/)
+- [第5章：GitHubアカウントとリポジトリ管理](docs/chapters/chapter05/)
 
 </details>
 
 <details>
 <summary><strong>🤖 第2部：AIツール活用編</strong></summary>
 
-- [第6章：GitHub Copilotの高度な活用](chapter-06-github-copilot-advanced.md)
-- [第7章：AI支援によるコードレビュー実践](chapter-07-ai-code-review-practice.md)
-- [第8章：GitHub Advanced SecurityとAI統合](chapter-08-github-advanced-security-ai.md)
+- [第6章：GitHub Copilotの高度な活用](docs/chapters/chapter06/)
+- [第7章：AI支援によるコードレビュー実践](docs/chapters/chapter07/)
+- [第8章：GitHub Advanced SecurityとAI統合](docs/chapters/chapter08/)
 
 </details>
 
 <details>
 <summary><strong>🔒 第3部：セキュリティと権限管理編</strong></summary>
 
-- [第9章：アクセス権限の体系](chapter-09-access-permissions-ai.md)
-- [第10章：組織管理とチーム運用](chapter-10-organization-management-ai.md)
-- [第11章：セキュリティ実践](chapter-11-security-practice-ai.md)
+- [第9章：アクセス権限の体系](docs/chapters/chapter09/)
+- [第10章：組織管理とチーム運用](docs/chapters/chapter10/)
+- [第11章：セキュリティ実践](docs/chapters/chapter11/)
 
 </details>
 
 <details>
 <summary><strong>⚙️ 第4部：実践編（チーム開発）</strong></summary>
 
-- [第12章：実践的なワークフロー設計](chapter-11-practical-workflow.md)
-- [第13章：CI/CDパイプライン構築](chapter-12-cicd-pipeline.md)
-- [第14章：大規模データとモデルの管理](chapter-14-large-scale-data-model-ai.md)
-- [第15章：GitHub Pagesでのプロジェクト公開](chapter-14-github-pages.md)
+- [第12章：実践的なワークフロー設計](docs/chapters/chapter12/)
+- [第13章：CI/CDパイプライン構築](docs/chapters/chapter13/)
+- [第14章：大規模データとモデルの管理](docs/chapters/chapter14/)
+- [第15章：GitHub Pagesでのプロジェクト公開](docs/chapters/chapter15/)
 
 </details>
 
 <details>
 <summary><strong>🏢 第5部：発展編（エンタープライズ対応）</strong></summary>
 
-- [第16章：外部協力者との連携](chapter-15-external-collaboration.md)
-- [第17章：コンプライアンスとガバナンス](chapter-16-compliance-governance.md)
+- [第16章：外部協力者との連携](docs/chapters/chapter16/)
+- [第17章：コンプライアンスとガバナンス](docs/chapters/chapter17/)
 
 </details>
 
 <details>
 <summary><strong>📚 付録・参考資料</strong></summary>
 
-- [付録A：GitHub用語集](appendix-a-github-glossary.md)
-- [付録B：トラブルシューティングガイド](appendix-b-troubleshooting.md)
-- [付録C：料金プランと機能比較表](appendix-c-pricing-comparison.md)
-- [付録D：AIツールのコスト計算例](appendix-d-ai-cost-calculation.md)
-- [付録E：便利なGitエイリアス集](appendix-e-git-aliases.md)
-- [付録F：推奨VS Code拡張機能](appendix-f-vscode-extensions.md)
+- [付録A：GitHub用語集](docs/appendices/appendix-a/)
+- [付録B：トラブルシューティングガイド](docs/appendices/appendix-b/)
+- [付録C：料金プランと機能比較表](docs/appendices/appendix-c/)
+- [付録D：AIツールのコスト計算例](docs/appendices/appendix-d/)
+- [付録E：便利なGitエイリアス集](docs/appendices/appendix-e/)
+- [付録F：推奨VS Code拡張機能](docs/appendices/appendix-f/)
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ npm run preview # ローカルプレビュー
 ## 📖 目次・章構成
 
 ### 📑 はじめに
-- [はじめに](introduction.md)
+- [はじめに](docs/introduction/)
 
 ### 第1部：AI協働時代の基礎編
 
-#### [第1章：GitとGitHubの基本概念](chapter-01-git-github-basics.md)
+#### [第1章：GitとGitHubの基本概念](docs/chapters/chapter01/)
 - 1.1 バージョン管理の必要性
 - 1.2 GitとGitHubの違い
 - 1.3 リポジトリの概念
@@ -57,7 +57,7 @@ npm run preview # ローカルプレビュー
 - 1.5 ブランチの基本
 - 1.6 ローカルとリモートの関係
 
-#### ⭐ [第2章：AI時代のGitHub協働基礎](chapter-02-ai-collaboration-fundamentals.md) **【新章】**
+#### ⭐ [第2章：AI時代のGitHub協働基礎](docs/chapters/chapter02/) **【新章】**
 - 2.1 なぜAI協働が必要なのか
 - 2.2 AIが理解しやすいIssueの書き方
 - 2.3 AI協働を前提としたPull Request
@@ -66,7 +66,7 @@ npm run preview # ローカルプレビュー
 - 2.6 実践的なワークフロー
 - 2.7 継続的な改善
 
-#### [第3章：必須コマンドとAI活用](chapter-03-essential-commands-ai.md)
+#### [第3章：必須コマンドとAI活用](docs/chapters/chapter03/)
 - 3.1 環境構築とGitの初期設定
 - 3.2 基本コマンド（clone, add, commit, push, pull）とAI支援
 - 3.3 ブランチ操作（checkout, branch, merge）の効率化
@@ -74,7 +74,7 @@ npm run preview # ローカルプレビュー
 - 3.5 AIを活用したコンフリクト解決
 - 3.6 .gitignoreの自動生成と最適化
 
-#### [第4章：GitHubでの協働作業入門](chapter-04-github-collaboration-ai.md)
+#### [第4章：GitHubでの協働作業入門](docs/chapters/chapter04/)
 - 4.1 実践例：AI支援による機械学習プロジェクト
 - 4.2 第2章のIssueテンプレートを使った作成実践
 - 4.3 AI協働型のブランチ作成からPull Requestまで
@@ -82,7 +82,7 @@ npm run preview # ローカルプレビュー
 - 4.5 ラベルとマイルストーンの活用
 - 4.6 AI最適化Issueテンプレートの実装
 
-#### [第5章：GitHubアカウントとリポジトリ管理](chapter-05-account-repository-ai.md)
+#### [第5章：GitHubアカウントとリポジトリ管理](docs/chapters/chapter05/)
 - 5.1 AI協働に最適化されたアカウント設定
 - 5.2 AI協働を考慮したアカウント種別の選択
 - 5.3 AI協働を考慮したPublic/Privateリポジトリの選択基準
@@ -91,21 +91,21 @@ npm run preview # ローカルプレビュー
 
 ### 第2部：AIツール活用編
 
-#### [第6章：GitHub Copilotの高度な活用](chapter-06-github-copilot-advanced.md)
+#### [第6章：GitHub Copilotの高度な活用](docs/chapters/chapter06/)
 - 6.1 第2章のCLEAR方式を使ったCopilot活用
 - 6.2 コード生成の効果的な使い方（実践編）
 - 6.3 AIペアプログラミングの発展的テクニック
 - 6.4 高度なプロンプトエンジニアリング
 - 6.5 Copilotの制限事項と対処法
 
-#### [第7章：AI支援によるコードレビュー実践](chapter-07-ai-code-review-practice.md)
+#### [第7章：AI支援によるコードレビュー実践](docs/chapters/chapter07/)
 - 7.1 第2章のPRテンプレートを使った実装
 - 7.2 自動レビューコメントの効果的な活用
 - 7.3 人間のレビューとAIレビューの協働パターン
 - 7.4 セキュリティ脆弱性の自動検出と対応
 - 7.5 AI協働履歴を活用したレビュー効率化
 
-#### [第8章：GitHub Advanced SecurityとAI統合](chapter-08-github-advanced-security-ai.md)
+#### [第8章：GitHub Advanced SecurityとAI統合](docs/chapters/chapter08/)
 - 8.1 AI生成コードのセキュリティ対策
 - 8.2 Secret scanningの活用
 - 8.3 Dependency reviewの実践
@@ -114,21 +114,21 @@ npm run preview # ローカルプレビュー
 
 ### 第3部：セキュリティと権限管理編
 
-#### [第9章：アクセス権限の体系](chapter-09-access-permissions-ai.md)
+#### [第9章：アクセス権限の体系](docs/chapters/chapter09/)
 - 9.1 AI協働を考慮した権限設計
 - 9.2 AI協働を考慮したブランチ保護ルール
 - 9.3 CODEOWNERSによる承認フロー
 - 9.4 Required reviewersの設定
 - 9.5 権限の継承と上書き
 
-#### [第10章：組織管理とチーム運用](chapter-10-organization-management-ai.md)
+#### [第10章：組織管理とチーム運用](docs/chapters/chapter10/)
 - 10.1 AI協働を前提としたOrganization設計
 - 10.2 AI協働チームの構造設計
 - 10.3 Outside Collaboratorの管理
 - 10.4 SAML SSOとの連携
 - 10.5 監査ログの活用
 
-#### [第11章：セキュリティ実践](chapter-11-security-practice-ai.md)
+#### [第11章：セキュリティ実践](docs/chapters/chapter11/)
 - 11.1 AI協働時代のSecrets管理
 - 11.2 Environment設定と環境変数
 - 11.3 Dependabotによる脆弱性対策
@@ -137,26 +137,26 @@ npm run preview # ローカルプレビュー
 
 ### 第4部：実践編（チーム開発）
 
-#### [第12章：実践的なワークフロー設計](chapter-11-practical-workflow.md)
+#### [第12章：実践的なワークフロー設計](docs/chapters/chapter12/)
 - 12.1 ケーススタディ：AI協働型モデル開発プロジェクト
 - 12.2 実験ブランチとメインラインの管理
 - 12.3 AI協働を考慮したリリース戦略
 
-#### [第13章：CI/CDパイプライン構築](chapter-12-cicd-pipeline.md)
+#### [第13章：CI/CDパイプライン構築](docs/chapters/chapter13/)
 - 13.1 GitHub Actionsの基本構造とAI活用
 - 13.2 AIモデル学習の自動化パイプライン
 - 13.3 第2章の品質ゲート実装
 - 13.4 AI協働による効率的なワークフロー作成
 - 13.5 継続的改善サイクルの実装
 
-#### [第14章：大規模データとモデルの管理](chapter-14-large-scale-data-model-ai.md)
+#### [第14章：大規模データとモデルの管理](docs/chapters/chapter14/)
 - 14.1 AI協働を考慮したGit LFS設定
 - 14.2 DVC（Data Version Control）との連携
 - 14.3 モデルレジストリの構築
 - 14.4 アクセス制御を考慮したデータ管理
 - 14.5 AI協働実験の追跡と管理
 
-#### [第15章：GitHub Pagesでのプロジェクト公開](chapter-14-github-pages.md)
+#### [第15章：GitHub Pagesでのプロジェクト公開](docs/chapters/chapter15/)
 - 15.1 GitHub Pagesの基本設定
 - 15.2 ML/AIプロジェクトのデモページ作成
 - 15.3 ドキュメントサイトの構築
@@ -165,14 +165,14 @@ npm run preview # ローカルプレビュー
 
 ### 第5部：発展編（エンタープライズ対応）
 
-#### [第16章：外部協力者との連携](chapter-15-external-collaboration.md)
+#### [第16章：外部協力者との連携](docs/chapters/chapter16/)
 - 16.1 Fork & Pull Requestモデル
 - 16.2 コントリビューターライセンス契約（CLA）
 - 16.3 外部貢献者の権限管理
 - 16.4 コントリビューションガイドラインの作成
 - 16.5 オープンソースプロジェクトの運営
 
-#### [第17章：コンプライアンスとガバナンス](chapter-16-compliance-governance.md)
+#### [第17章：コンプライアンスとガバナンス](docs/chapters/chapter17/)
 - 17.1 ライセンス管理の基本
 - 17.2 Export Control対応
 - 17.3 AIツール利用時の知的財産権配慮
@@ -181,22 +181,22 @@ npm run preview # ローカルプレビュー
 
 ### 📚 付録
 
-#### [付録A：GitHub用語集](appendix-a-github-glossary.md)
+#### [付録A：GitHub用語集](docs/appendices/appendix-a/)
 AI協働関連用語を含む包括的な用語集
 
-#### [付録B：トラブルシューティングガイド](appendix-b-troubleshooting.md)
+#### [付録B：トラブルシューティングガイド](docs/appendices/appendix-b/)
 AI協働特有の問題と解決策
 
-#### [付録C：料金プランと機能比較表](appendix-c-pricing-comparison.md)
+#### [付録C：料金プランと機能比較表](docs/appendices/appendix-c/)
 AI機能を含む最新の料金・機能比較
 
-#### [付録D：AIツールのコスト計算例](appendix-d-ai-cost-calculation.md)
+#### [付録D：AIツールのコスト計算例](docs/appendices/appendix-d/)
 ROI計算とコスト効果分析
 
-#### [付録E：便利なGitエイリアス集](appendix-e-git-aliases.md)
+#### [付録E：便利なGitエイリアス集](docs/appendices/appendix-e/)
 AI協働向けの効率的なGitエイリアス
 
-#### [付録F：推奨VS Code拡張機能](appendix-f-vscode-extensions.md)
+#### [付録F：推奨VS Code拡張機能](docs/appendices/appendix-f/)
 AI協働に最適化された開発環境設定
 
 ## 🌟 特別コンテンツ

--- a/repository-management-guide.md
+++ b/repository-management-guide.md
@@ -174,7 +174,7 @@ github-workflow-book-private/
 ## 関連ドキュメント
 
 - [デプロイメントガイド](deployment-guide.md) - デプロイの詳細手順
-- [開発ガイド](development-guide.md) - 開発環境のセットアップ
+- [開発ガイド](DEVELOPMENT.md) - 開発環境のセットアップ
 - [コントリビューションガイド](CONTRIBUTING.md) - 貢献方法
 
 ## サポート

--- a/src/chapters/chapter05/index.md
+++ b/src/chapters/chapter05/index.md
@@ -315,13 +315,13 @@ predictions = model.predict(image)
 Full documentation is available at [https://docs.example.com](https://docs.example.com)
 
 ## Examples
-See the [examples/](examples/) directory for more examples.
+See the [examples/](../../../examples/) directory for more examples.
 
 ## Contributing
-Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct.
+Please read [CONTRIBUTING.md](../../../CONTRIBUTING.md) for details on our code of conduct.
 
 ## License
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](../../../LICENSE) file for details.
 
 ## Citation
 If you use this software in your research, please cite:


### PR DESCRIPTION
check-links で検出された broken internal links を解消しました。

- README.md / PUBLICATION_INDEX.md の章・付録リンクを実在パス（docs/chapters, docs/appendices, docs/introduction）へ更新
- repository-management-guide.md の関連ドキュメント参照を実在ファイルへ更新
- KINDLE_COMPLETE.md の目次アンカーに対応する章/付録見出し（プレースホルダ）を追加
- src/chapters/chapter05/index.md の相対リンクを修正