### PR TITLE
docs: make environment examples less version-stale

### DIFF
--- a/docs/chapters/chapter02/index.md
+++ b/docs/chapters/chapter02/index.md
@@ -36,9 +36,9 @@ GitHub Actions による品質ゲートやメトリクス収集（2.6〜2.7）�
 # [BUG] ログイン認証でランダムに401エラーが発生
 
 ## 環境情報
-- OS: Ubuntu 20.04
-- Python: 3.9.7
-- Django: 4.1.2
+- OS: Ubuntu LTS（例: 22.04）
+- Python: 3.x
+- Django: 4.x
 - 発生頻度: 約20%のログイン試行
 
 ## 再現手順

--- a/docs/chapters/chapter04/index.md
+++ b/docs/chapters/chapter04/index.md
@@ -159,10 +159,10 @@ Title: [FEATURE] データ拡張機能の追加
 Title: [BUG] バッチサイズ1でモデル推論時にエラー発生
 
 ## 環境情報
-- OS: Ubuntu 20.04
-- Python: 3.9.0
-- PyTorch: 2.0.0
-- CUDA: 11.7
+- OS: Ubuntu LTS（例: 22.04）
+- Python: 3.x
+- PyTorch: 2.x
+- CUDA: 11.x
 - 発生頻度: バッチサイズ1の時100%再現
 
 ## 再現手順

--- a/docs/chapters/chapter05/index.md
+++ b/docs/chapters/chapter05/index.md
@@ -285,7 +285,7 @@ Protect matching branches:
 
 [![Build Status](https://travis-ci.org/username/repo.svg?branch=main)](https://travis-ci.org/username/repo)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Python Version](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
+[![Python Version](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 
 One-line description of your project.
 
@@ -297,7 +297,7 @@ One-line description of your project.
 ## Installation
 
 ### Requirements
-- Python 3.8+
+- Python 3.10+
 - PyTorch 1.9+
 - CUDA 11.0+ (for GPU support)
 


### PR DESCRIPTION
品質スプリント（it-engineer-knowledge-architecture#105）対応。

環境例・README例に固定の古いバージョン表記が含まれていたため、陳腐化しにくい形に一般化しました。
- Ubuntu 20.04 -> Ubuntu LTS（例: 22.04）
- Python/Django/PyTorch/CUDA: patch固定 -> major系（3.x/4.x/2.x/11.x）
- README例の Python 3.8+ -> 3.10+

関連: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/105