### PR TITLE
fix: require Node.js 20 in easy-setup

### DIFF
--- a/easy-setup.js
+++ b/easy-setup.js
@@ -76,8 +76,9 @@ class EasySetup {
     const nodeVersion = process.version;
     const majorVersion = parseInt(nodeVersion.slice(1).split('.')[0]);
     
-    if (majorVersion < 18) {
-      throw new Error(`Node.js 18以上が必要です。現在: ${nodeVersion}`);
+    // Keep aligned with package.json engines.node (>=20.0.0)
+    if (majorVersion < 20) {
+      throw new Error(`Node.js 20以上が必要です。現在: ${nodeVersion}`);
     }
     
     // Git check


### PR DESCRIPTION
# 変更内容
- `easy-setup.js` の Node.js バージョンチェックを **18以上 → 20以上** に更新

# 背景
- 既に `package.json` の `engines.node` は `>=20.0.0` へ更新済みですが、`easy-setup.js` 側が `majorVersion < 18` のままで不整合でした。

# 確認事項
- 既存の `package.json`/CI の方針（Node.js 20+）と整合すること

# 関連
- itdojp/it-engineer-knowledge-architecture Issue #102
- 直前のEOL更新PR: https://github.com/itdojp/github-workflow-book/pull/174
