### PR TITLE
書籍内の GitHub Actions 記述例を v4 に更新

### DIFF
--- a/docs/appendices/appendix-g/index.md
+++ b/docs/appendices/appendix-g/index.md
@@ -1151,7 +1151,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Run policy scanner
         id: scan

--- a/docs/chapters/chapter08/index.md
+++ b/docs/chapters/chapter08/index.md
@@ -53,7 +53,7 @@ jobs:
         
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
@@ -328,7 +328,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         
       - name: Dependency Review
         uses: actions/dependency-review-action@v3
@@ -424,7 +424,7 @@ jobs:
   security-fix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Run Security Analysis
         id: security

--- a/docs/chapters/chapter11/index.md
+++ b/docs/chapters/chapter11/index.md
@@ -163,7 +163,7 @@ jobs:
   ai-security-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: AI Placeholder Detection
       run: |
@@ -184,7 +184,7 @@ jobs:
     environment: production
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
@@ -468,7 +468,7 @@ jobs:
     
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       
     - name: Metadata
       id: metadata
@@ -742,7 +742,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     # 1. CodeQL
     - name: Initialize CodeQL

--- a/docs/chapters/chapter13/index.md
+++ b/docs/chapters/chapter13/index.md
@@ -102,7 +102,7 @@ test:
   runs-on: ${{ matrix.os }}
   
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
@@ -228,7 +228,7 @@ jobs:
     runs-on: [self-hosted, gpu]  # セルフホストランナー（GPU付き）
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Setup ML environment
         uses: ./.github/actions/setup-ml-env
@@ -332,7 +332,7 @@ jobs:
       matrix: ${{ steps.generate.outputs.matrix }}
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Generate experiment matrix
         id: generate
@@ -352,7 +352,7 @@ jobs:
     runs-on: [self-hosted, gpu]
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Setup environment
         uses: ./.github/actions/setup-ml-env
@@ -377,7 +377,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Collect all results
         run: |
@@ -423,7 +423,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -453,7 +453,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Setup ML environment
         uses: ./.github/actions/setup-ml-env
@@ -505,7 +505,7 @@ jobs:
           - 6379:6379
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Setup environment
         uses: ./.github/actions/setup-ml-env
@@ -521,7 +521,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Setup environment
         uses: ./.github/actions/setup-ml-env
@@ -709,7 +709,7 @@ jobs:
     runs-on: [self-hosted, gpu-cluster]
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Setup distributed environment
         run: |
@@ -747,7 +747,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       # Docker層のキャッシュ
       - name: Set up Docker Buildx
@@ -814,7 +814,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Download model artifact
         uses: actions/download-artifact@v3
@@ -849,7 +849,7 @@ jobs:
     environment: staging
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
@@ -878,7 +878,7 @@ jobs:
     environment: production
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Deploy canary version
         run: |

--- a/docs/chapters/chapter15/index.md
+++ b/docs/chapters/chapter15/index.md
@@ -76,7 +76,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Setup Pages
         uses: actions/configure-pages@v3
@@ -886,7 +886,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: gh-pages
           
@@ -943,7 +943,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Full history for git-revision-date
           

--- a/docs/chapters/chapter16/index.md
+++ b/docs/chapters/chapter16/index.md
@@ -1028,7 +1028,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           

--- a/src/appendices/appendix-g/index.md
+++ b/src/appendices/appendix-g/index.md
@@ -1145,7 +1145,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Run policy scanner
         id: scan

--- a/src/chapters/chapter07/index.md
+++ b/src/chapters/chapter07/index.md
@@ -390,7 +390,7 @@ jobs:
   ai-review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Run Copilot Review
         uses: github/copilot-review-action@v1

--- a/src/chapters/chapter08/index.md
+++ b/src/chapters/chapter08/index.md
@@ -48,7 +48,7 @@ jobs:
         
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
@@ -323,7 +323,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         
       - name: Dependency Review
         uses: actions/dependency-review-action@v3
@@ -419,7 +419,7 @@ jobs:
   security-fix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Run Security Analysis
         id: security

--- a/src/chapters/chapter11/index.md
+++ b/src/chapters/chapter11/index.md
@@ -158,7 +158,7 @@ jobs:
   ai-security-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: AI Placeholder Detection
       run: |
@@ -179,7 +179,7 @@ jobs:
     environment: production
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
@@ -463,7 +463,7 @@ jobs:
     
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       
     - name: Metadata
       id: metadata
@@ -737,7 +737,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     # 1. CodeQL
     - name: Initialize CodeQL

--- a/src/chapters/chapter13/index.md
+++ b/src/chapters/chapter13/index.md
@@ -56,7 +56,7 @@ jobs:
       cache-hit: ${{ steps.cache.outputs.cache-hit }}
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Set up Python
         id: setup
@@ -98,7 +98,7 @@ test:
   runs-on: ${{ matrix.os }}
   
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
@@ -223,7 +223,7 @@ jobs:
     runs-on: [self-hosted, gpu]  # セルフホストランナー（GPU付き）
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Setup ML environment
         uses: ./.github/actions/setup-ml-env
@@ -327,7 +327,7 @@ jobs:
       matrix: ${{ steps.generate.outputs.matrix }}
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Generate experiment matrix
         id: generate
@@ -347,7 +347,7 @@ jobs:
     runs-on: [self-hosted, gpu]
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Setup environment
         uses: ./.github/actions/setup-ml-env
@@ -372,7 +372,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Collect all results
         run: |
@@ -418,7 +418,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -448,7 +448,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Setup ML environment
         uses: ./.github/actions/setup-ml-env
@@ -500,7 +500,7 @@ jobs:
           - 6379:6379
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Setup environment
         uses: ./.github/actions/setup-ml-env
@@ -516,7 +516,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Setup environment
         uses: ./.github/actions/setup-ml-env
@@ -704,7 +704,7 @@ jobs:
     runs-on: [self-hosted, gpu-cluster]
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Setup distributed environment
         run: |
@@ -742,7 +742,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       # Docker層のキャッシュ
       - name: Set up Docker Buildx
@@ -809,7 +809,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Download model artifact
         uses: actions/download-artifact@v3
@@ -844,7 +844,7 @@ jobs:
     environment: staging
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
@@ -873,7 +873,7 @@ jobs:
     environment: production
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Deploy canary version
         run: |

--- a/src/chapters/chapter15/index.md
+++ b/src/chapters/chapter15/index.md
@@ -71,7 +71,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Setup Pages
         uses: actions/configure-pages@v3
@@ -881,7 +881,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: gh-pages
           
@@ -938,7 +938,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Full history for git-revision-date
           

--- a/src/chapters/chapter16/index.md
+++ b/src/chapters/chapter16/index.md
@@ -1019,7 +1019,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           


### PR DESCRIPTION
Issue #102 の残作業（非推奨記述の棚卸し）対応です。

- 書籍内の GitHub Actions 記述例で `actions/checkout@v3` を `actions/checkout@v4` に更新
- `src` / `docs` / `appendix` の重複管理ファイルを同期更新
