### PR TITLE
CI記述例の @master 参照をバージョンタグへ更新

### DIFF
--- a/docs/chapters/chapter11/index.md
+++ b/docs/chapters/chapter11/index.md
@@ -768,7 +768,7 @@ jobs:
         
     # 3. Snyk
     - name: Run Snyk to check for vulnerabilities
-      uses: snyk/actions/python@v1
+      uses: snyk/actions/python@v1.0.0
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       with:

--- a/src/chapters/chapter11/index.md
+++ b/src/chapters/chapter11/index.md
@@ -763,7 +763,7 @@ jobs:
         
     # 3. Snyk
     - name: Run Snyk to check for vulnerabilities
-      uses: snyk/actions/python@v1
+      uses: snyk/actions/python@v1.0.0
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
       with:


### PR DESCRIPTION
## 概要
- 書籍本文の GitHub Actions 記述例に残っている @master 参照を、明示バージョンタグへ更新

## 変更内容
- aquasecurity/trivy-action@master -> aquasecurity/trivy-action@0.33.1
- snyk/actions/python@master -> snyk/actions/python@v1.0.0

## 補足
- 本PRは、当該リポジトリに実在する該当記述のみを更新しています。
- Issue: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102