### PR TITLE
CI記述例の codeql-action 参照を v4 に更新

### DIFF
--- a/docs/chapters/chapter08/index.md
+++ b/docs/chapters/chapter08/index.md
@@ -56,16 +56,16 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         queries: +security-extended,+security-and-quality
         
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v4
       
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{ matrix.language }}"
         
@@ -428,7 +428,7 @@ jobs:
       
       - name: Run Security Analysis
         id: security
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v4
         
       - name: Generate Fixes with AI
         uses: github/copilot-security-fix@v1

--- a/docs/chapters/chapter11/index.md
+++ b/docs/chapters/chapter11/index.md
@@ -746,12 +746,12 @@ jobs:
     
     # 1. CodeQL
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: 'python, javascript'
         
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4
       
     # 2. Trivy (コンテナスキャン)
     - name: Run Trivy vulnerability scanner
@@ -762,7 +762,7 @@ jobs:
         output: 'trivy-results.sarif'
         
     - name: Upload Trivy results
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: 'trivy-results.sarif'
         

--- a/src/chapters/chapter08/index.md
+++ b/src/chapters/chapter08/index.md
@@ -51,16 +51,16 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         queries: +security-extended,+security-and-quality
         
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v4
       
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{ matrix.language }}"
         
@@ -423,7 +423,7 @@ jobs:
       
       - name: Run Security Analysis
         id: security
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v4
         
       - name: Generate Fixes with AI
         uses: github/copilot-security-fix@v1

--- a/src/chapters/chapter11/index.md
+++ b/src/chapters/chapter11/index.md
@@ -741,12 +741,12 @@ jobs:
     
     # 1. CodeQL
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: 'python, javascript'
         
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4
       
     # 2. Trivy (コンテナスキャン)
     - name: Run Trivy vulnerability scanner
@@ -757,7 +757,7 @@ jobs:
         output: 'trivy-results.sarif'
         
     - name: Upload Trivy results
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: 'trivy-results.sarif'
         


### PR DESCRIPTION
## 概要
- 書籍本文の GitHub Actions 記述例に残る `github/codeql-action@v2` 系参照を `@v4` に更新

## 変更内容
- `github/codeql-action/init@v2` -> `@v4`
- `github/codeql-action/analyze@v2` -> `@v4`
- `github/codeql-action/upload-sarif@v2` -> `@v4`
- `github/codeql-action/autobuild@v2` -> `@v4`

## 補足
- 本PRは当該リポジトリに実在する記述のみ更新
- Issue: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102
