### PR TITLE
CI記述例の Docker Actions 参照を v3 に更新

### DIFF
--- a/docs/chapters/chapter11/index.md
+++ b/docs/chapters/chapter11/index.md
@@ -194,7 +194,7 @@ jobs:
         aws-region: us-east-1
     
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/docs/chapters/chapter13/index.md
+++ b/docs/chapters/chapter13/index.md
@@ -751,7 +751,7 @@ jobs:
       
       # Docker層のキャッシュ
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         
       - name: Cache Docker layers
         uses: actions/cache@v4

--- a/src/chapters/chapter11/index.md
+++ b/src/chapters/chapter11/index.md
@@ -189,7 +189,7 @@ jobs:
         aws-region: us-east-1
     
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/src/chapters/chapter13/index.md
+++ b/src/chapters/chapter13/index.md
@@ -746,7 +746,7 @@ jobs:
       
       # Docker層のキャッシュ
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         
       - name: Cache Docker layers
         uses: actions/cache@v4


### PR DESCRIPTION
## 概要
- 書籍本文の Docker 関連 GitHub Actions 記述例で、`@v2` 参照を `@v3` に更新

## 変更内容
- `docker/setup-buildx-action@v2` -> `@v3`
- `docker/login-action@v2` -> `@v3`

## 補足
- 本PRは当該リポジトリに実在する記述のみ更新
- Issue: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102
