### PR TITLE
CI記述例の追加Action参照を更新

### DIFF
--- a/deployment-guide.md
+++ b/deployment-guide.md
@@ -147,7 +147,7 @@ jobs:
         rm -f .nojekyll
 
     - name: Deploy to public repository using peaceiris/actions-gh-pages
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         personal_token: ${{ secrets.PUBLIC_REPO_TOKEN }}
         external_repository: itdojp/github-workflow-book-public

--- a/docs/chapters/chapter13/index.md
+++ b/docs/chapters/chapter13/index.md
@@ -118,7 +118,7 @@ test:
         pytest tests/ -v --cov=src --cov-report=xml
         
     - name: Upload coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         file: ./coverage.xml
         flags: unittests

--- a/docs/chapters/chapter15/index.md
+++ b/docs/chapters/chapter15/index.md
@@ -989,7 +989,7 @@ jobs:
             -o {} {} \;
             
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site

--- a/src/chapters/chapter13/index.md
+++ b/src/chapters/chapter13/index.md
@@ -114,7 +114,7 @@ test:
         pytest tests/ -v --cov=src --cov-report=xml
         
     - name: Upload coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         file: ./coverage.xml
         flags: unittests

--- a/src/chapters/chapter15/index.md
+++ b/src/chapters/chapter15/index.md
@@ -984,7 +984,7 @@ jobs:
             -o {} {} \;
             
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site


### PR DESCRIPTION
## 概要
- 書籍本文の GitHub Actions 記述例で、旧参照を更新

## 変更内容
- codecov/codecov-action@v5
- peaceiris/actions-gh-pages@v4

## 補足
- 本PRは当該リポジトリに実在する記述のみ更新
- Issue: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102
