### PR TITLE
docs: dependabot/fetch-metadata を v2 に更新

### DIFF
--- a/docs/chapters/chapter11/index.md
+++ b/docs/chapters/chapter11/index.md
@@ -467,32 +467,32 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
       
-    - name: Metadata
-      id: metadata
-      uses: dependabot/fetch-metadata@v2
-      with:
-        github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
         
-    - name: Auto-merge for patch and minor updates
-      if: |
-        steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-        steps.metadata.outputs.update-type == 'version-update:semver-minor'
-      run: gh pr merge --auto --merge "$PR_URL"
-      env:
-        PR_URL: ${{ github.event.pull_request.html_url }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Auto-merge for patch and minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
-    - name: Approve PR
-      if: |
-        steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-        steps.metadata.outputs.update-type == 'version-update:semver-minor'
-      run: gh pr review --approve "$PR_URL"
-      env:
-        PR_URL: ${{ github.event.pull_request.html_url }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Approve PR
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ### 脆弱性レポートの生成

--- a/src/chapters/chapter11/index.md
+++ b/src/chapters/chapter11/index.md
@@ -462,32 +462,32 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
       
-    - name: Metadata
-      id: metadata
-      uses: dependabot/fetch-metadata@v2
-      with:
-        github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
         
-    - name: Auto-merge for patch and minor updates
-      if: |
-        steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-        steps.metadata.outputs.update-type == 'version-update:semver-minor'
-      run: gh pr merge --auto --merge "$PR_URL"
-      env:
-        PR_URL: ${{ github.event.pull_request.html_url }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Auto-merge for patch and minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
-    - name: Approve PR
-      if: |
-        steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-        steps.metadata.outputs.update-type == 'version-update:semver-minor'
-      run: gh pr review --approve "$PR_URL"
-      env:
-        PR_URL: ${{ github.event.pull_request.html_url }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Approve PR
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ### 脆弱性レポートの生成


### PR DESCRIPTION
- 章11のサンプル workflow で `dependabot/fetch-metadata@v1` を `@v2` に更新
- `docs` と `src` を同期更新

関連: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102