### PR TITLE
docs: actions/setup-python を v6 に更新

### DIFF
--- a/docs/chapters/chapter13/index.md
+++ b/docs/chapters/chapter13/index.md
@@ -105,7 +105,7 @@ test:
     - uses: actions/checkout@v4
     
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     
@@ -157,7 +157,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
     
@@ -426,7 +426,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.9'
       

--- a/docs/chapters/chapter15/index.md
+++ b/docs/chapters/chapter15/index.md
@@ -948,7 +948,7 @@ jobs:
           fetch-depth: 0  # Full history for git-revision-date
           
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.9'
           

--- a/src/chapters/chapter13/index.md
+++ b/src/chapters/chapter13/index.md
@@ -60,7 +60,7 @@ jobs:
       
       - name: Set up Python
         id: setup
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       
@@ -101,7 +101,7 @@ test:
     - uses: actions/checkout@v4
     
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     
@@ -152,7 +152,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
     
@@ -421,7 +421,7 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.9'
       

--- a/src/chapters/chapter15/index.md
+++ b/src/chapters/chapter15/index.md
@@ -943,7 +943,7 @@ jobs:
           fetch-depth: 0  # Full history for git-revision-date
           
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.9'
           


### PR DESCRIPTION
- 章13/15のWorkflow例で `actions/setup-python@v4` を `@v6` に更新
- `docs` と `src` を同期更新

関連: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102