### PR TITLE
docs: docker/build-push-action の例を v6 に更新

### DIFF
--- a/docs/chapters/chapter13/index.md
+++ b/docs/chapters/chapter13/index.md
@@ -780,7 +780,7 @@ jobs:
       
       # ビルドとテスト
       - name: Build Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: false

--- a/src/chapters/chapter13/index.md
+++ b/src/chapters/chapter13/index.md
@@ -775,7 +775,7 @@ jobs:
       
       # ビルドとテスト
       - name: Build Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: false


### PR DESCRIPTION
## 概要
- ドキュメント/サンプル内の `docker/build-push-action@v4` を `@v6` に更新
- 参照先を最新メジャー（`docker/build-push-action` latest: `v6.19.1`）へ追随

## 変更
- `docker/build-push-action@v4` -> `docker/build-push-action@v6`

Closes #102