### PR TITLE
chore(ci): bump book-formatter pin to da2a49e

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: itdojp/book-formatter
-          ref: 2a0180954286b731cb0d91545aa77e9ee478570d
+          ref: da2a49e7d2dcd9e1fa885e910c458130fe8d73a4
           path: book-formatter
 
       - name: Setup Node.js


### PR DESCRIPTION
## 概要
- `book-formatter` の pin を `2a0180954286b731cb0d91545aa77e9ee478570d` から `da2a49e7d2dcd9e1fa885e910c458130fe8d73a4` へ更新します。
- 変更対象はCIワークフローのみです。

## 変更ファイル
- `.github/workflows/book-qa.yml`

## 背景
- `book-formatter` 側で markdown-structure の既定除外に `build/**` が追加されたため、最新pinへ追随します。
