### PR TITLE
src: chapter03 のテンプレート用コードフェンスを修正

### DIFF
--- a/src/chapters/chapter03/index.md
+++ b/src/chapters/chapter03/index.md
@@ -110,7 +110,7 @@ git add -p
 #### AIを使った効率的なファイル選択
 第2章のCLEAR方式を使って、AIに適切なファイルの選択を依頼できます：
 
-```markdown
+````markdown
 ## AI指示例（第2章のCLEAR方式を使用）
 
 ### Context
@@ -130,20 +130,20 @@ git add -p
 
 ### Example
 期待する出力形式：
-```
+```text
 Modified files:
 - data/preprocessor.py (本機能)
 - tests/test_preprocessor.py (テスト)
 - README.md (ドキュメント)
 - debug_output.log (一時ファイル)
-```text
+```
 
 ### Action
 適切なgit addコマンドを提案してください。
 
 ### Review
 セキュリティリスクやコミット範囲の妥当性をチェックしてください。
-```
+````
 
 **AI回答例**：
 ```bash


### PR DESCRIPTION
## 変更内容
- `src/chapters/chapter03/index.md` の CLEAR 方式の例（Markdownテンプレート）で、コードフェンスの入れ子が崩れていた箇所を修正しました。
- `docs/` 側と同様に、外側を ````markdown で囲い、内側の ```text を正しく表現できるようにしました。

## 背景
- 現状はフェンスが競合し、以降の見出し/本文が意図せずコードブロックとして扱われる可能性がありました。

## 影響
- 表示/体裁およびテンプレートのコピペ容易性の改善で、内容の趣旨は変更しません。
