### PR TITLE
docs: プレースホルダのDiscordリンクを削除

### DIFF
--- a/docs/chapters/chapter16/index.md
+++ b/docs/chapters/chapter16/index.md
@@ -524,7 +524,6 @@ pre-commit install
 4. CLA must be signed
 
 ## Community
-- Join our [Discord server](https://discord.gg/xxxxx)
 - Attend our monthly contributor meetings
 - Check out our [roadmap](https://github.com/itdojp/github-workflow-book-public/projects/1)
 

--- a/src/chapters/chapter16/index.md
+++ b/src/chapters/chapter16/index.md
@@ -515,7 +515,6 @@ pre-commit install
 4. CLA must be signed
 
 ## Community
-- Join our [Discord server](https://discord.gg/xxxxx)
 - Attend our monthly contributor meetings
 - Check out our [roadmap](https://github.com/itdojp/github-workflow-book-public/projects/1)
 


### PR DESCRIPTION
## 変更内容
- `docs/` / `src/` の Chapter 16 から、プレースホルダの Discord 招待リンク（`discord.gg/xxxxx`）を削除しました。

## 背景
- 実在しないURL（プレースホルダ）のまま公開されると、読者に誤解を与えるため。

## 影響
- コミュニティ案内の体裁のみ変更で、手順や主張の内容は変更しません。
