### PR TITLE
docs: PRテンプレ例のCloses表記を調整

### DIFF
--- a/docs/chapters/chapter07/index.md
+++ b/docs/chapters/chapter07/index.md
@@ -51,7 +51,7 @@ AIレビューを「運用」に落とすには、レビューの前提を成果
 - 人間が最終確認した観点：
 
 ## 受入条件（Issue）
-- Closes #123
+- Closes #<issue-number>
 ```
 
 ### `.github/copilot-instructions.md` 例（抜粋）


### PR DESCRIPTION
## 変更内容
- PRテンプレート例の `Closes #xxxx` を、例として分かりやすい `Closes #123` に変更しました。

## 背景
- `xxxx` のままだとプレースホルダに見え、読者に「このまま使って良いのか」が伝わりにくいため。

## 影響
- 表示/体裁の調整のみで、テンプレートの意図は変更しません。
