### PR TITLE
fix: srcのネストしたコードフェンスを解消

### DIFF
--- a/src/chapters/chapter04/index.md
+++ b/src/chapters/chapter04/index.md
@@ -150,7 +150,7 @@ Title: [FEATURE] データ拡張機能の追加
 ```
 
 #### AI協働型バグ報告の例（第2章のテンプレート適用）
-```markdown
+````markdown
 Title: [BUG] バッチサイズ1でモデル推論時にエラー発生
 
 ## 環境情報
@@ -193,7 +193,7 @@ BatchNorm層がtraining=Trueの状態でバッチサイズ1を処理できない
 - bug
 - high-priority
 - ai-investigation
-```text
+````
 
 #### Issueテンプレートの活用
 `.github/ISSUE_TEMPLATE/`にテンプレートを配置：
@@ -324,7 +324,7 @@ Fixes #5
 #### レビューコメントの例
 
 **レビュアー1のコメント：**
-```markdown
+````markdown
 Line 15 in data_loader.py:
 
 ```python
@@ -332,7 +332,7 @@ transforms.RandomCrop(224, padding=4),
 ```
 
 画像サイズが224固定になっていますが、設定可能にした方が良いのでは？
-```text
+````
 
 **対応方法1：コードの修正**
 ```python
@@ -367,7 +367,7 @@ def get_train_transforms(image_size=224):
 ```
 
 **対応方法2：議論**
-```markdown
+````markdown
 確かにタスクによって適切な拡張の強度は異なりますね。
 現在は画像分類を想定していますが、将来的に他のタスクにも対応することを考えると、
 拡張の強度も設定可能にすべきでしょうか？
@@ -383,7 +383,7 @@ def get_train_transforms(image_size=224, aug_strength='medium'):
 ```
 
 どう思われますか？
-```text
+````
 
 #### 修正の追加コミット
 ```bash

--- a/src/chapters/chapter05/index.md
+++ b/src/chapters/chapter05/index.md
@@ -275,7 +275,7 @@ Protect matching branches:
 
 ### 効果的なREADMEの構造
 
-```markdown
+````markdown
 # Project Name
 
 [![Build Status](https://travis-ci.org/username/repo.svg?branch=main)](https://travis-ci.org/username/repo)
@@ -315,13 +315,13 @@ predictions = model.predict(image)
 Full documentation is available at [https://docs.example.com](https://docs.example.com)
 
 ## Examples
-See the [examples/](../../../examples/) directory for more examples.
+See the [examples/](examples/) directory for more examples.
 
 ## Contributing
-Please read [CONTRIBUTING.md](../../../CONTRIBUTING.md) for details on our code of conduct.
+Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct.
 
 ## License
-This project is licensed under the MIT License - see the [LICENSE](../../../LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
 ## Citation
 If you use this software in your research, please cite:
@@ -337,7 +337,7 @@ If you use this software in your research, please cite:
 ## Acknowledgments
 - Acknowledgment 1
 - Acknowledgment 2
-```text
+````
 
 ### ライセンスの選択
 
@@ -369,7 +369,7 @@ If you use this software in your research, please cite:
 Settings → Template repository にチェック
 
 #### 標準構造
-```
+```text
 ml-project-template/
 ├── .github/
 │   ├── workflows/
@@ -390,7 +390,7 @@ ml-project-template/
 ├── LICENSE
 ├── CONTRIBUTING.md
 └── .gitignore
-```text
+```
 
 ### セキュリティポリシー
 

--- a/src/chapters/chapter07/index.md
+++ b/src/chapters/chapter07/index.md
@@ -14,7 +14,7 @@
 ### 第2章テンプレートの実装例
 以下は、第2章で学んだPRテンプレートを実際のプロジェクトで使用した例です：
 
-```markdown
+````markdown
 # [FEATURE] ユーザー認証のレート制限実装
 
 ## 🤖 AI協働履歴
@@ -36,7 +36,7 @@ class LoginRateLimiter:
 - **開発速度**: ベースライン比2.1倍高速
 - **バグ発見率**: AI提案での事前発見 2件
 - **コードレビュー効率**: レビュー時間1.3時間短縮
-```text
+````
 
 ### 有効化手順
 
@@ -97,7 +97,7 @@ review_preferences:
 ### レビューコメントの種類
 
 #### 1. セキュリティ指摘
-```python
+````python
 # PR内のコード
 def connect_to_database(password):
     conn_string = f"postgresql://user:{password}@localhost/db"
@@ -116,10 +116,10 @@ def connect_to_database():
     return psycopg2.connect(conn_string)
 ```
 """
-```text
+````
 
 #### 2. パフォーマンス改善
-```python
+````python
 # PR内のコード
 def process_images(image_list):
     results = []
@@ -146,10 +146,10 @@ def process_images_batch(image_list):
     return results
 ```
 """
-```text
+````
 
 #### 3. コードスタイル
-```python
+````python
 # PR内のコード
 def calculate_metrics(y_true,y_pred,threshold = 0.5):
     tp=np.sum((y_true==1)&(y_pred>=threshold))
@@ -170,7 +170,7 @@ def calculate_metrics(y_true, y_pred, threshold=0.5):
 - docstringの追加
 - 意味のある変数名の使用を検討
 """
-```text
+````
 
 ### コメントへの対応方法
 
@@ -276,7 +276,7 @@ priority_rules:
 ### 検出可能な脆弱性
 
 #### 1. インジェクション攻撃
-```python
+````python
 # 脆弱なコード
 def search_users(query):
     sql = f"SELECT * FROM users WHERE name = '{query}'"
@@ -294,10 +294,10 @@ def search_users(query):
     return db.execute(sql, (query,))
 ```
 """
-```text
+````
 
 #### 2. 認証・認可の問題
-```python
+````python
 # 脆弱なコード
 @app.route('/admin/users')
 def admin_users():
@@ -317,10 +317,10 @@ def admin_users():
     return render_template('admin_users.html', users=get_all_users())
 ```
 """
-```text
+````
 
 #### 3. 機密情報の露出
-```python
+````python
 # 脆弱なコード
 logger.info(f"User login attempt: {username}, password: {password}")
 
@@ -335,7 +335,7 @@ logger.info(f"User login attempt: {username}")
 # パスワードは記録しない
 ```
 """
-```text
+````
 
 ### セキュリティレポートの活用
 

--- a/src/chapters/chapter08/index.md
+++ b/src/chapters/chapter08/index.md
@@ -146,7 +146,7 @@ Medium severity (5)
 ```
 
 #### アラートの詳細情報
-```markdown
+````markdown
 ## Path traversal in file upload
 
 **Severity**: High
@@ -170,7 +170,7 @@ filepath = os.path.join(UPLOAD_DIR, filename)
 ### References
 - CWE-22: Path Traversal
 - OWASP: Path Traversal
-```text
+````
 
 ## 7.2 Secret scanningの活用
 

--- a/src/chapters/chapter16/index.md
+++ b/src/chapters/chapter16/index.md
@@ -5,7 +5,7 @@
 ### Fork & PRワークフローの基本
 
 #### 外部協力者向けのワークフロー
-```markdown
+````markdown
 # Contributing Guide for External Collaborators
 
 ## Getting Started
@@ -42,12 +42,12 @@
    - Push your branch to your fork
    - Create a PR from your fork to the main repository
    - Fill out the PR template completely
-```text
+````
 
 ### フォーク管理の自動化
 
 #### フォーク同期スクリプト
-```python
+````python
 # scripts/fork_manager.py
 import subprocess
 import requests
@@ -127,7 +127,7 @@ Let us know if you need any help!
         except:
             # Issueが無効な場合はスキップ
             pass
-```text
+````
 
 ### Pull Requestテンプレート
 
@@ -236,7 +236,7 @@ jobs:
 ### CLAドキュメント
 
 #### CLA.md
-```markdown
+````markdown
 # Contributor License Agreement
 
 ## Purpose
@@ -269,8 +269,8 @@ You are not expected to provide support for Your Contributions, except to the ex
 Comment on the PR with:
 ```
 I have read the CLA Document and I hereby sign the CLA
-```text
 ```
+````
 
 ### CLA管理システム
 
@@ -449,7 +449,7 @@ class ContributorManager:
 ### 外部コントリビューター向けのガイドライン
 
 #### CONTRIBUTING.md
-```markdown
+````markdown
 # Contributing to ML Project
 
 We love your input! We want to make contributing to this project as easy and transparent as possible.
@@ -529,7 +529,7 @@ We recognize our contributors! Check out our [Contributors page](https://github.
 
 ## License
 By contributing, you agree that your contributions will be licensed under the same license as the project.
-```text
+````
 
 ## 16.4 コントリビューションガイドラインの作成
 


### PR DESCRIPTION
## 変更内容\n- src配下の章ファイルで、```markdown/```python などの3バッククォートコードフェンス内に別のコードフェンスが出現してレンダリングが崩れる箇所を修正しました。\n- 外側のフェンスを4バッククォート（````）に変更し、意図通りに例が表示されるようにしています。\n\n## 対象\n- src/chapters/chapter04/index.md\n- src/chapters/chapter05/index.md\n- src/chapters/chapter07/index.md\n- src/chapters/chapter08/index.md\n- src/chapters/chapter16/index.md\n\n## 補足\n- docs側は既に修正済みのため、今回の変更はsrc側の整合性確保（将来の生成/再同期で再発しないこと）を目的としています。