### PR TITLE
docs: Built with とリポジトリリンクを現行に更新

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -194,9 +194,9 @@ ChatGPT/GitHub Copilot/Claude等のAI開発者ツールとGitHubを統合した�
 
 **著者**: 太田和彦（株式会社アイティードゥ）  
 **ライセンス**: CC BY-NC-SA 4.0（商用は別契約）  
-**リポジトリ**: [GitHub](https://github.com/itdojp/github-workflow-book-private)
+**リポジトリ**: [GitHub](https://github.com/itdojp/github-workflow-book)
 
 ---
 
-*Built with [Book Publishing Template v2.0](https://github.com/itdojp/book-publishing-template2)*
+*Built with [book-formatter](https://github.com/itdojp/book-formatter)*
 {% include page-navigation.html %}


### PR DESCRIPTION
## 目的
- GitHub Pages 上のメタ情報（リポジトリURL / `Built with`）を現行の構成に合わせます。

## 変更内容
- `docs/index.md`:
  - `Built with` を `book-formatter` に更新。
  - リポジトリURLを `itdojp/github-workflow-book` に統一（旧URLはリネーム元のため）。
