### PR TITLE
chore: fix npm audit vulnerabilities (#210)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "markdownlint-cli": "^0.47.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": "20 || >=22"
       },
       "optionalDependencies": {
         "puppeteer": "^24.37.5",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/itdojp/github-workflow-book.git"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": "20 || >=22"
   },
   "scripts": {
     "setup": "node easy-setup.js",


### PR DESCRIPTION
Closes #210

## 概要
`npm audit` で検出されていた脆弱性（high/moderate）を解消し、監査結果を 0 件にしました。

## 変更内容
- `optionalDependencies` の `puppeteer` を更新（監査で指摘される `tar-fs` / `ws` 系の経路を解消）
- `devDependencies` の `markdownlint-cli` を更新（監査で指摘される `js-yaml` / `minimatch` 系の経路を解消）
- `overrides` で `minimatch` を 10.2.1 以上へ強制（ReDoS 指摘の解消）
- `engines.node` を `20 || >=22` に更新（transitive deps が Node 21 を許容しないため）

## 影響/リスク
- `puppeteer` は optional だがメジャー更新のため、`scripts/build-pdf.js` 等の実行環境によっては挙動差分が発生し得ます。

## テスト
- `npm audit --omit=dev --audit-level=high` → found 0 vulnerabilities
- `npm audit --audit-level=high` → found 0 vulnerabilities

## ロールバック
- 本PRを revert し、依存関係更新を取り消す
