### PR TITLE
docs: ナビの目次アイコンを削除

### DIFF
--- a/docs/_includes/navigation.html
+++ b/docs/_includes/navigation.html
@@ -63,7 +63,6 @@
     {% endif %}
     
     <a href="{{ site.baseurl }}/" class="nav-home">
-      <span class="icon">📚</span>
       <span class="label">目次へ</span>
     </a>
     
@@ -170,11 +169,6 @@
 
 .nav-next .arrow {
   margin-left: 0.5rem;
-}
-
-.nav-home .icon {
-  margin-right: 0.5rem;
-  font-size: 1.2rem;
 }
 
 .label {

--- a/templates/navigation/navigation.html
+++ b/templates/navigation/navigation.html
@@ -63,7 +63,6 @@
     {% endif %}
     
     <a href="{{ site.baseurl }}/" class="nav-home">
-      <span class="icon">📚</span>
       <span class="label">目次へ</span>
     </a>
     
@@ -170,11 +169,6 @@
 
 .nav-next .arrow {
   margin-left: 0.5rem;
-}
-
-.nav-home .icon {
-  margin-right: 0.5rem;
-  font-size: 1.2rem;
 }
 
 .label {


### PR DESCRIPTION
## 変更内容
- ナビゲーション（「目次へ」）のアイコン（📚）と関連CSSを削除（`docs/` と `templates/`）

## 検証
- node ../book-formatter/scripts/check-unicode.js docs --allowlist .book-formatter/unicode-allowlist.json --fail-on warn
- node ../book-formatter/scripts/check-textlint.js docs --fail-on error
- node ../book-formatter/scripts/check-links.js docs
- node ../book-formatter/scripts/check-layout-risk.js docs --fail-on error
- node ../book-formatter/scripts/check-markdown-structure.js docs --fail-on error
