### PR TITLE
[codex] PR完了ゲートとリリース運用証跡を強化する

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,10 +28,24 @@
 - リスク:
 - ロールバック手順:
 
+## Review 対応（必須）
+
+- [ ] review 本文・inline comment・suggestion を全件確認した
+- [ ] 修正した指摘には返信した
+- [ ] 修正しない指摘には理由を返信した
+- [ ] 未解決の review thread が 0 件である
+
 ## QA（必須）
 
 - [ ] Book QA（Unicode / textlint(PRH) / 内部リンク・アンカー / Jekyll build / built-site smoke）: PASS
   - 実行URL:
+- [ ] 必須 status checks が green である
+
+## merge 後確認（原則必須）
+
+- [ ] main の checks が green である
+- [ ] release / deploy / Pages など公開先の smoke test を実施した
+- [ ] 完了証跡を関連 Issue に記録した
 
 ## Pages確認（原則必須）
 

--- a/docs/chapters/chapter12/index.md
+++ b/docs/chapters/chapter12/index.md
@@ -824,6 +824,27 @@ class ReviewAutomation:
         }
 ```
 
+### PR完了ゲートとレビュー応答の標準手順
+
+レビューを効率化しても、最終的な完了判断を曖昧にすると品質ゲートが形骸化します。PR は
+「作成」「レビュー依頼」「コメント対応」「CI」「merge 後確認」を 1 つの流れとして扱います。
+
+| ゲート | 確認すること | 証跡 |
+| --- | --- | --- |
+| PR body | Issue、受入基準、検証コマンド、リスク、ロールバック、AI利用有無が書かれている | PR body |
+| Review | review 本文、inline comment、suggestion を全件確認した | 修正 commit と返信 |
+| 変更不要判断 | 修正しない指摘に理由がある | 該当 thread への返信 |
+| Conversation | 未解決の review thread が 0 件である | GitHub の Resolve / Unresolve 状態 |
+| CI | 必須チェックが green である | Checks タブ、または merge queue の結果 |
+| merge 後 | main の checks、Pages / release / deploy 先、主要 smoke test を確認した | Issue コメントまたは監査メモ |
+
+AI生成PRでも人間作成PRでも、完了条件は同じです。AIレビューだけで完了扱いにせず、
+「指摘をどう扱ったか」「CI が何を検証したか」「merge 後にどこまで見たか」を残すことで、
+後続の `github-guide-for-beginners-book` や `issue-driven-work-book` と同じ証跡粒度に揃えられます。
+
+機密情報を含むログ、顧客データ、token は、PR body、review comment、AI/外部サービスへ貼り付けません。
+必要な場合はマスクした要約、再現用の最小ログ、またはアクセス権限を制限した内部証跡へ分離します。
+
 ### レビューの自動化とメトリクス
 
 #### レビュー効率化ダッシュボード

--- a/docs/chapters/chapter13/index.md
+++ b/docs/chapters/chapter13/index.md
@@ -41,7 +41,25 @@ on:
 参考:
 - merge queue: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
 - `merge_group` イベント: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#merge_group
+- `GITHUB_TOKEN`: https://docs.github.com/en/actions/tutorials/authenticate-with-github_token
+- environments: https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments
 - サンプル: `examples/merge-queue-ci-example/`
+
+### 必須チェックと権限境界の設計
+
+GitHub Actions を PR 完了ゲートに使う場合、単に workflow を置くだけでなく、
+「どのイベントで」「どの権限で」「どの check 名を必須にするか」まで運用設計に含めます。
+
+- rulesets / branch protection で必須にする check 名は、`pull_request` と `merge_group` の双方で成功するようにする
+- merge queue を使う場合は、必須チェックの workflow に `merge_group` を追加する
+- `GITHUB_TOKEN` は `permissions:` で job ごとに最小権限へ絞り、Release 作成など write が必要な job だけに付与する
+- production deploy は `environment:`、required reviewers、deployment branches / tags、environment secrets を組み合わせる
+- fork PR や外部協力者 PR では、Secrets を使う deploy / release / publish job を実行しない
+
+2026-05-23（Asia/Tokyo）時点の GitHub Docs では、merge queue の required checks には
+`merge_group` イベント対応が必要であり、`GITHUB_TOKEN` の権限は `permissions` キーで
+workflow または job 単位に調整できます。環境ごとの deploy では environment secrets と
+保護ルールを使い、承認後にのみ secrets へアクセスできる設計にします。
 
 #### AI協働品質ゲート統合のワークフロー構造
 **実運用例（このまま使える）**：全文は `examples/ai-collaboration-pipeline-example/` を参照してください。以下は最小構成の例です（チェック内容はプロジェクトに合わせて置き換えます）。

--- a/examples/ai-agent-starter/.github/PULL_REQUEST_TEMPLATE.md
+++ b/examples/ai-agent-starter/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,13 +14,24 @@
 
 ## 受入基準（Issue）
 
-- Closes #<issue-number>
+- Closes #ISSUE_NUMBER
 - [ ] Issue の受入基準を満たす
 
 ## 検証
 
 - 自動テスト:
 - 手動確認:
+
+## Review 対応
+
+- [ ] review 本文・inline comment・suggestion を全件確認した
+- [ ] 修正/変更不要理由を返信した
+- [ ] 未解決の review thread が 0 件である
+
+## merge 後確認
+
+- [ ] main checks / release / deploy / Pages の必要な確認を実施した
+- [ ] 関連 Issue に完了証跡を記録した
 
 ## ロールバック
 

--- a/examples/merge-queue-ci-example/README.md
+++ b/examples/merge-queue-ci-example/README.md
@@ -1,6 +1,7 @@
 # merge queue 対応のCI最小例
 
-この例は、GitHub の merge queue を有効にしたリポジトリで、必須チェック（required status checks）を満たすために GitHub Actions を `pull_request` と `merge_group` の両方で起動する構成を示します。
+この例は、GitHub の merge queue を有効にしたリポジトリで、必須チェック（required status checks）を
+満たすために GitHub Actions を `pull_request` と `merge_group` の両方で起動する構成を示します。
 
 - 参照（公式）:
   - merge queue: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
@@ -15,5 +16,12 @@
 1. `.github/workflows/ci.yml` を対象リポジトリへコピーします。
 2. rulesets / branch protection で、このワークフローのチェック名を「必須チェック」として要求します。
 3. merge queue を有効化します。
+
+## 運用チェック
+
+- [ ] `pull_request` と `merge_group` の両方で同じ check 名が成功する
+- [ ] merge queue に入れる前に review thread が 0 件である
+- [ ] 失敗時に queue から外れた理由を PR / Issue に記録する
+- [ ] Secrets や deploy は fork PR / merge_group イベントの信頼境界に合わせて job を分離する
 
 このサンプルは「トリガー設計」を示すための最小構成です。実プロジェクトでは `Run checks` を実際のテスト/静的解析/セキュリティ検査に置き換えてください。

--- a/examples/release-automation-example/README.md
+++ b/examples/release-automation-example/README.md
@@ -17,4 +17,14 @@
 
 - `gh release create` は `GITHUB_TOKEN` を利用します。Release作成には `permissions: contents: write` が必要になることがあります。
 - fork PR など不特定入力の実行では、公開系処理を走らせない設計に分離してください。
+- 公式Docs: https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases
+- 自動生成 release notes: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
 
+## リリース前後のゲート
+
+- [ ] 対象 commit / tag / release 範囲が合意されている
+- [ ] main または release branch の必須チェックが green である
+- [ ] 自動生成 release notes に機微情報や不要な bot 更新が混ざっていない
+- [ ] 成果物の作成手順とハッシュ/サイズを記録している
+- [ ] 失敗時の rollback / re-release / 周知手順がある
+- [ ] Release 作成後、成果物、主要リンク、deploy 先を smoke test した

--- a/src/chapters/chapter12/index.md
+++ b/src/chapters/chapter12/index.md
@@ -782,6 +782,27 @@ class ReviewAutomation:
         }
 ```
 
+### PR完了ゲートとレビュー応答の標準手順
+
+レビューを効率化しても、最終的な完了判断を曖昧にすると品質ゲートが形骸化します。PR は
+「作成」「レビュー依頼」「コメント対応」「CI」「merge 後確認」を 1 つの流れとして扱います。
+
+| ゲート | 確認すること | 証跡 |
+| --- | --- | --- |
+| PR body | Issue、受入基準、検証コマンド、リスク、ロールバック、AI利用有無が書かれている | PR body |
+| Review | review 本文、inline comment、suggestion を全件確認した | 修正 commit と返信 |
+| 変更不要判断 | 修正しない指摘に理由がある | 該当 thread への返信 |
+| Conversation | 未解決の review thread が 0 件である | GitHub の Resolve / Unresolve 状態 |
+| CI | 必須チェックが green である | Checks タブ、または merge queue の結果 |
+| merge 後 | main の checks、Pages / release / deploy 先、主要 smoke test を確認した | Issue コメントまたは監査メモ |
+
+AI生成PRでも人間作成PRでも、完了条件は同じです。AIレビューだけで完了扱いにせず、
+「指摘をどう扱ったか」「CI が何を検証したか」「merge 後にどこまで見たか」を残すことで、
+後続の `github-guide-for-beginners-book` や `issue-driven-work-book` と同じ証跡粒度に揃えられます。
+
+機密情報を含むログ、顧客データ、token は、PR body、review comment、AI/外部サービスへ貼り付けません。
+必要な場合はマスクした要約、再現用の最小ログ、またはアクセス権限を制限した内部証跡へ分離します。
+
 ### レビューの自動化とメトリクス
 
 #### レビュー効率化ダッシュボード

--- a/src/chapters/chapter13/index.md
+++ b/src/chapters/chapter13/index.md
@@ -36,7 +36,25 @@ on:
 参考:
 - merge queue: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
 - `merge_group` イベント: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#merge_group
+- `GITHUB_TOKEN`: https://docs.github.com/en/actions/tutorials/authenticate-with-github_token
+- environments: https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments
 - サンプル: `examples/merge-queue-ci-example/`
+
+### 必須チェックと権限境界の設計
+
+GitHub Actions を PR 完了ゲートに使う場合、単に workflow を置くだけでなく、
+「どのイベントで」「どの権限で」「どの check 名を必須にするか」まで運用設計に含めます。
+
+- rulesets / branch protection で必須にする check 名は、`pull_request` と `merge_group` の双方で成功するようにする
+- merge queue を使う場合は、必須チェックの workflow に `merge_group` を追加する
+- `GITHUB_TOKEN` は `permissions:` で job ごとに最小権限へ絞り、Release 作成など write が必要な job だけに付与する
+- production deploy は `environment:`、required reviewers、deployment branches / tags、environment secrets を組み合わせる
+- fork PR や外部協力者 PR では、Secrets を使う deploy / release / publish job を実行しない
+
+2026-05-23（Asia/Tokyo）時点の GitHub Docs では、merge queue の required checks には
+`merge_group` イベント対応が必要であり、`GITHUB_TOKEN` の権限は `permissions` キーで
+workflow または job 単位に調整できます。環境ごとの deploy では environment secrets と
+保護ルールを使い、承認後にのみ secrets へアクセスできる設計にします。
 
 #### AI協働品質ゲート統合のワークフロー構造
 **実運用例（このまま使える）**：全文は `examples/ai-collaboration-pipeline-example/` を参照してください。以下は最小構成の例です（チェック内容はプロジェクトに合わせて置き換えます）。


### PR DESCRIPTION
## 概要

Closes #228

#153 / #155 Phase 2 の 2冊目として、GitHub ワークフロー実践ガイドの PR 完了ゲート、review 対応、CI / merge queue、release / deploy 後確認の証跡粒度を強化しました。

## 主な変更

- 第12章に「PR完了ゲートとレビュー応答の標準手順」を追加
  - review 本文、inline comment、suggestion の全件確認
  - 変更不要判断の返信
  - 未解決 review thread 0 件
  - CI green、merge 後確認、Issue/監査メモへの証跡記録
- 第13章に「必須チェックと権限境界の設計」を追加
  - `pull_request` / `merge_group` の必須チェック整合
  - `GITHUB_TOKEN` の `permissions:` 最小化
  - environment / required reviewers / deployment branches or tags / environment secrets の使い分け
- `.github/PULL_REQUEST_TEMPLATE.md` と AI agent starter の PR テンプレートに review 対応・merge 後確認欄を追加
- merge queue 例に運用チェックを追加
- release automation 例にリリース前後のゲートを追加

## 確認範囲と変更判断

- `docs/` は公開物、`src/` はビルド入力として扱い、章本文の追加は `docs/chapters/chapter12`, `docs/chapters/chapter13` と対応 `src/` に反映しました。
- 既存の章全体の markdownlint baseline は大きいため、本 PR では #228 の受入範囲に直結するゲート/テンプレート/例に限定しました。
- Actions の細かな UI 操作ではなく、workflow イベント、権限境界、environment、release 証跡という実務上の不変条件に寄せています。

## 公式情報の確認

2026-05-23（Asia/Tokyo）時点で、以下の GitHub 公式ドキュメントを確認しました。

- merge queue: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
- `merge_group` event: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#merge_group
- `GITHUB_TOKEN` permissions: https://docs.github.com/en/actions/tutorials/authenticate-with-github_token
- environments: https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments
- releases: https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases
- generated release notes: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes

## ローカル検証

- [x] `npm ci` 成功（npm audit は 10件: 6 moderate, 3 high, 1 critical）
- [x] `git diff --check`
- [x] focused markdownlint
  - `.github/PULL_REQUEST_TEMPLATE.md`
  - `examples/ai-agent-starter/.github/PULL_REQUEST_TEMPLATE.md`
  - `examples/merge-queue-ci-example/README.md`
  - `examples/release-automation-example/README.md`
- [x] marker smoke
  - `PR完了ゲートとレビュー応答の標準手順`
  - `未解決の review thread が 0 件である`
  - `必須チェックと権限境界の設計`
  - `environment secrets`
  - `リリース前後のゲート`
- [x] isolated copy under `.codex-local/tmp/github-workflow-build-check` で `npm ci --no-fund --no-audit` + `npm run build` 成功

## 既存の検証上の注意

- `npm run lint:light` は既存の `src/**/*.md` markdownlint baseline により失敗します。
- `python3 scripts/validate_links.py docs` は既存のサンプルURL / placeholder URL / リンクパーサ起因の baseline により失敗します。
- `npm run build` は `docs/` を大きく再生成するため、作業ツリーを汚さないよう isolated copy で実行しました。

## 残リスク / follow-up

- `src/**/*.md` の markdownlint baseline 整理
- `scripts/validate_links.py` の placeholder / サンプルURL除外ルール整理
- npm audit 10件の依存関係更新