### PR TITLE
[codex] Add metadata consistency gate

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -33,6 +33,9 @@ jobs:
           cache: npm
           cache-dependency-path: book-formatter/package-lock.json
 
+      - name: Book metadata consistency check
+        run: node scripts/check-metadata-consistency.js
+
       - name: Install dependencies (book-formatter)
         working-directory: book-formatter
         run: npm ci

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ __pycache__/
 .pytest_cache/
 
 # Documentation build
+docs/Gemfile.lock
 _site/
 .sass-cache/
 .jekyll-cache/

--- a/.markdownlint-src.json
+++ b/.markdownlint-src.json
@@ -1,0 +1,58 @@
+{
+  "default": true,
+  "MD003": {
+    "style": "atx"
+  },
+  "MD004": {
+    "style": "dash"
+  },
+  "MD007": {
+    "indent": 2
+  },
+  "MD013": false,
+  "MD022": false,
+  "MD024": {
+    "siblings_only": true
+  },
+  "MD025": false,
+  "MD026": {
+    "punctuation": ".,;:!"
+  },
+  "MD029": false,
+  "MD031": false,
+  "MD032": false,
+  "MD033": {
+    "allowed_elements": [
+      "br",
+      "hr",
+      "img",
+      "a",
+      "details",
+      "summary",
+      "code",
+      "pre",
+      "sup",
+      "sub",
+      "kbd"
+    ]
+  },
+  "MD034": false,
+  "MD040": false,
+  "MD041": false,
+  "MD046": {
+    "style": "fenced"
+  },
+  "MD047": false,
+  "MD048": {
+    "style": "backtick"
+  },
+  "MD049": {
+    "style": "underscore"
+  },
+  "MD050": {
+    "style": "asterisk"
+  },
+  "MD009": false,
+  "MD036": false,
+  "MD060": false
+}

--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@
 ### 📋 クイックスタート
 ```bash
 PUPPETEER_SKIP_DOWNLOAD=true npm ci  # 依存関係インストール
-npm run check:metadata              # 公開メタデータ確認
-npm run test:light                  # 軽量QA + Jekyllビルド
+npm run test:light                  # メタデータ確認 + 軽量QA + Jekyllビルド
 npm run preview                     # ローカルプレビュー
 ```
 
@@ -29,7 +28,7 @@ npm run preview                     # ローカルプレビュー
 ### 🧪 品質確認
 
 - `npm run check:metadata`: `package.json`、`book-config.json`、`docs/_config.yml`、`docs/index.md`、公開ナビゲーションの整合性を確認します。
-- `npm run test:light`: メタデータ確認、legacy `src/` Markdown lint、公開 `docs/` の Jekyll ビルドをまとめて実行します。
+- `npm run test:light`: メタデータ確認、legacy `src/` Markdown lint、公開 `docs/` の Jekyll ビルドをまとめて実行します。Jekyll build 前に `docs/Gemfile` の bundle を確認し、未導入ならインストールします。
 - `npm run build:generate`: `src/` から `docs/` を再生成する旧テンプレート用コマンドです。通常の公開確認は `npm run build` を使用します。
 
 ## 📚 書籍概要

--- a/README.md
+++ b/README.md
@@ -18,12 +18,19 @@
 
 ### 📋 クイックスタート
 ```bash
-npm install    # 依存関係インストール
-npm run build  # ビルド
-npm run preview # ローカルプレビュー
+PUPPETEER_SKIP_DOWNLOAD=true npm ci  # 依存関係インストール
+npm run check:metadata              # 公開メタデータ確認
+npm run test:light                  # 軽量QA + Jekyllビルド
+npm run preview                     # ローカルプレビュー
 ```
 
 詳細は [SETUP_V2.md](SETUP_V2.md) を参照してください。
+
+### 🧪 品質確認
+
+- `npm run check:metadata`: `package.json`、`book-config.json`、`docs/_config.yml`、`docs/index.md`、公開ナビゲーションの整合性を確認します。
+- `npm run test:light`: メタデータ確認、legacy `src/` Markdown lint、公開 `docs/` の Jekyll ビルドをまとめて実行します。
+- `npm run build:generate`: `src/` から `docs/` を再生成する旧テンプレート用コマンドです。通常の公開確認は `npm run build` を使用します。
 
 ## 📚 書籍概要
 
@@ -257,7 +264,7 @@ AI協働に最適化された開発環境設定
 **著者**: 株式会社アイティードゥ 太田和彦  
 **発行日**: 2025年6月1日
 
-- Email: author@example.com
+- Email: knowledge@itdo.jp
 - Twitter: @username
 - LinkedIn: /in/username
 

--- a/book-config.json
+++ b/book-config.json
@@ -14,7 +14,8 @@
     "repository": {
       "url": "https://github.com/itdojp/github-workflow-book",
       "zenn": "https://zenn.dev/itdojp/books/github-workflow-ai"
-    }
+    },
+    "version": "1.1.0"
   },
   "deployment": {
     "sourceFolder": "docs",

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,7 @@
 title: "AI開発のためのGitHubワークフロー実践ガイド"
 description: "ChatGPT/GitHub Copilot/Claude等のAI開発者ツールとGitHubを統合した開発手法を体系的に解説。AI時代のソフトウェア開発に必要なワークフロー、セキュリティ、ガバナンス、大規模開発の実践的ノウハウを網羅。"
 author: "太田和彦"
+version: "1.1.0"
 baseurl: "/github-workflow-book"
 url: "https://itdojp.github.io"
 

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -51,3 +51,6 @@ appendices:
   path: /appendices/appendix-f/
 - title: 付録G：参考資料
   path: /appendices/appendix-g/
+afterword:
+- title: あとがき
+  path: /afterword/

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,8 @@
 layout: book
 order: 1
 title: "AI開発のためのGitHubワークフロー実践ガイド"
-author: "株式会社アイティードゥ"
-version: "1.0.0"
+author: "太田和彦"
+version: "1.1.0"
 permalink: /
 ---
 
@@ -195,6 +195,10 @@ ChatGPT/GitHub Copilot/Claude等のAI開発者ツールとGitHubを統合した�
 #### [付録E：便利なGitエイリアス集](appendices/appendix-e/)
 #### [付録F：推奨VS Code拡張機能](appendices/appendix-f/)
 #### [付録G：参考資料](appendices/appendix-g/)
+
+### あとがき
+
+#### [あとがき](afterword/)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "book-publishing-template-improved",
-  "version": "2.0.0",
+  "name": "github-workflow-book",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "book-publishing-template-improved",
-      "version": "2.0.0",
+      "name": "github-workflow-book",
+      "version": "1.1.0",
       "license": "CC-BY-NC-SA-4.0",
       "dependencies": {
         "fs-extra": "^11.3.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "book-publishing-template-improved",
-  "version": "2.0.0",
-  "description": "Improved Book Publishing Template with Easy Setup",
-  "author": "Book Publishing Template Contributors",
+  "name": "github-workflow-book",
+  "version": "1.1.0",
+  "description": "ChatGPT/GitHub Copilot/Claude等のAI開発者ツールとGitHubを統合した開発手法を体系的に解説。AI時代のソフトウェア開発に必要なワークフロー、セキュリティ、ガバナンス、大規模開発の実践的ノウハウを網羅。",
+  "author": "太田和彦（株式会社アイティードゥ） <knowledge@itdo.jp>",
   "license": "CC-BY-NC-SA-4.0",
   "repository": {
     "type": "git",
@@ -13,14 +13,16 @@
   },
   "scripts": {
     "setup": "node easy-setup.js",
-    "build": "node scripts/build-simple.js",
+    "build": "cd docs && bundle exec jekyll build --config _config.yml --source . --destination ../_site",
     "build:full": "node scripts/build.js",
-    "preview": "npm run build && npx http-server public -p 8080 --silent",
+    "preview": "npm run build && npx http-server _site -p 8080 --silent",
     "deploy": "bash scripts/deploy.sh",
-    "clean": "rm -rf public output temp",
-    "lint:light": "markdownlint 'src/**/*.md' --ignore node_modules",
-    "test:light": "npm run lint:light && npm run build",
-    "help": "echo 'Available commands:\n  npm run setup - Interactive setup\n  npm run build - Build the book\n  npm run preview - Local preview\n  npm run deploy - Deploy to GitHub Pages'"
+    "clean": "rm -rf _site public output temp",
+    "lint:light": "markdownlint --config .markdownlint-src.json 'src/**/*.md' --ignore node_modules",
+    "test:light": "npm run check:metadata && npm run lint:light && npm run build",
+    "help": "echo 'Available commands:\n  npm run setup - Interactive setup\n  npm run build - Build the book\n  npm run preview - Local preview\n  npm run deploy - Deploy to GitHub Pages'",
+    "build:generate": "node scripts/build-simple.js",
+    "check:metadata": "node scripts/check-metadata-consistency.js"
   },
   "dependencies": {
     "fs-extra": "^11.3.0",
@@ -38,15 +40,14 @@
     "minimatch": "^10.2.1"
   },
   "keywords": [
+    "github",
+    "workflow",
+    "ai-development",
     "book",
-    "publishing",
-    "markdown",
-    "github-pages",
-    "template",
-    "easy-setup"
+    "github-pages"
   ],
   "bugs": {
     "url": "https://github.com/itdojp/github-workflow-book/issues"
   },
-  "homepage": "https://github.com/itdojp/github-workflow-book#readme"
+  "homepage": "https://itdojp.github.io/github-workflow-book/"
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "setup": "node easy-setup.js",
-    "build": "cd docs && bundle exec jekyll build --config _config.yml --source . --destination ../_site",
+    "build": "cd docs && (bundle check || bundle install) && bundle exec jekyll build --config _config.yml --source . --destination ../_site",
     "build:full": "node scripts/build.js",
     "preview": "npm run build && npx http-server _site -p 8080 --silent",
     "deploy": "bash scripts/deploy.sh",

--- a/scripts/check-metadata-consistency.js
+++ b/scripts/check-metadata-consistency.js
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const EXPECTED = {
+  repo: 'itdojp/github-workflow-book',
+  repoUrl: 'https://github.com/itdojp/github-workflow-book',
+  repoGitUrl: 'https://github.com/itdojp/github-workflow-book.git',
+  pagesUrl: 'https://itdojp.github.io/github-workflow-book/',
+  packageName: 'github-workflow-book',
+  version: '1.1.0',
+  title: 'AI開発のためのGitHubワークフロー実践ガイド',
+  description: 'ChatGPT/GitHub Copilot/Claude等のAI開発者ツールとGitHubを統合した開発手法を体系的に解説。AI時代のソフトウェア開発に必要なワークフロー、セキュリティ、ガバナンス、大規模開発の実践的ノウハウを網羅。',
+  authorName: '太田和彦',
+  authorOrganization: '株式会社アイティードゥ',
+  authorEmail: 'knowledge@itdo.jp',
+  packageLicense: 'CC-BY-NC-SA-4.0',
+  bookLicense: 'CC BY-NC-SA 4.0',
+  baseurl: '/github-workflow-book',
+  siteUrl: 'https://itdojp.github.io'
+};
+
+const EXPECTED_NAV = {
+  introduction: ['/introduction/'],
+  chapters: Array.from({ length: 17 }, (_, i) => `/chapters/chapter${String(i + 1).padStart(2, '0')}/`),
+  appendices: ['a', 'b', 'c', 'd', 'e', 'f', 'g'].map((letter) => `/appendices/appendix-${letter}/`),
+  afterword: ['/afterword/']
+};
+
+const errors = [];
+
+function fail(message) {
+  errors.push(message);
+}
+
+function readText(file) {
+  try {
+    return fs.readFileSync(file, 'utf8');
+  } catch (error) {
+    fail(`${file}: failed to read (${error.message})`);
+    return '';
+  }
+}
+
+function readJson(file) {
+  try {
+    return JSON.parse(readText(file));
+  } catch (error) {
+    fail(`${file}: invalid JSON (${error.message})`);
+    return {};
+  }
+}
+
+function normalizeScalar(value) {
+  if (value === undefined || value === null) return value;
+  let s = String(value).trim();
+  const commentIndex = s.search(/\s+#/);
+  if (commentIndex >= 0) s = s.slice(0, commentIndex).trim();
+  if ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'"))) {
+    s = s.slice(1, -1);
+  }
+  return s;
+}
+
+function parseTopLevelYaml(file) {
+  const data = {};
+  for (const line of readText(file).split(/\r?\n/)) {
+    if (!line.trim() || line.trimStart().startsWith('#')) continue;
+    const match = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (match) data[match[1]] = normalizeScalar(match[2]);
+  }
+  return data;
+}
+
+function parseFrontMatter(file) {
+  const text = readText(file);
+  if (!text.startsWith('---')) {
+    fail(`${file}: missing YAML front matter`);
+    return { data: {}, body: text };
+  }
+  const end = text.indexOf('\n---', 3);
+  if (end === -1) {
+    fail(`${file}: missing closing YAML front matter delimiter`);
+    return { data: {}, body: text };
+  }
+  const raw = text.slice(3, end);
+  const data = {};
+  for (const line of raw.split(/\r?\n/)) {
+    const match = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (match) data[match[1]] = normalizeScalar(match[2]);
+  }
+  return { data, body: text.slice(end + 4) };
+}
+
+function parseNavigation(file) {
+  const nav = {};
+  let current = null;
+  for (const line of readText(file).split(/\r?\n/)) {
+    const section = line.match(/^([A-Za-z0-9_-]+):\s*$/);
+    if (section) {
+      current = section[1];
+      nav[current] = nav[current] || [];
+      continue;
+    }
+    const pathMatch = line.match(/^\s*path:\s*(.+?)\s*$/);
+    if (current && pathMatch) {
+      nav[current].push(normalizeScalar(pathMatch[1]));
+    }
+  }
+  return nav;
+}
+
+function expectEqual(label, actual, expected) {
+  if (actual !== expected) {
+    fail(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+function expectArrayEqual(label, actual, expected) {
+  const actualJson = JSON.stringify(actual);
+  const expectedJson = JSON.stringify(expected);
+  if (actualJson !== expectedJson) {
+    fail(`${label}: expected ${expectedJson}, got ${actualJson}`);
+  }
+}
+
+function expectFileExists(label, file) {
+  if (!fs.existsSync(file)) {
+    fail(`${label}: missing ${file}`);
+  }
+}
+
+function trimTrailingSlash(url) {
+  return String(url || '').replace(/\/+$/, '');
+}
+
+function validatePackage() {
+  const pkg = readJson('package.json');
+  expectEqual('package.json name', pkg.name, EXPECTED.packageName);
+  expectEqual('package.json version', pkg.version, EXPECTED.version);
+  expectEqual('package.json description', pkg.description, EXPECTED.description);
+  expectEqual('package.json author', pkg.author, `${EXPECTED.authorName}（${EXPECTED.authorOrganization}） <${EXPECTED.authorEmail}>`);
+  expectEqual('package.json license', pkg.license, EXPECTED.packageLicense);
+  expectEqual('package.json repository.type', pkg.repository && pkg.repository.type, 'git');
+  expectEqual('package.json repository.url', pkg.repository && pkg.repository.url, EXPECTED.repoGitUrl);
+  expectEqual('package.json homepage', pkg.homepage, EXPECTED.pagesUrl);
+  expectEqual('package.json bugs.url', pkg.bugs && pkg.bugs.url, `${EXPECTED.repoUrl}/issues`);
+  if (!pkg.scripts || !pkg.scripts['check:metadata']) {
+    fail('package.json scripts.check:metadata: missing');
+  }
+
+  const lock = readJson('package-lock.json');
+  expectEqual('package-lock.json name', lock.name, EXPECTED.packageName);
+  expectEqual('package-lock.json version', lock.version, EXPECTED.version);
+  const root = lock.packages && lock.packages[''];
+  if (!root) {
+    fail('package-lock.json packages[""]: missing root package metadata');
+  } else {
+    expectEqual('package-lock.json packages[""].name', root.name, EXPECTED.packageName);
+    expectEqual('package-lock.json packages[""].version', root.version, EXPECTED.version);
+    expectEqual('package-lock.json packages[""].license', root.license, EXPECTED.packageLicense);
+  }
+}
+
+function validateBookConfig() {
+  const cfg = readJson('book-config.json');
+  const book = cfg.book || {};
+  expectEqual('book-config.json book.title', book.title, EXPECTED.title);
+  expectEqual('book-config.json book.version', book.version, EXPECTED.version);
+  expectEqual('book-config.json book.description', book.description, EXPECTED.description);
+  expectEqual('book-config.json book.author.name', book.author && book.author.name, EXPECTED.authorName);
+  expectEqual('book-config.json book.author.email', book.author && book.author.email, EXPECTED.authorEmail);
+  expectEqual('book-config.json book.author.organization', book.author && book.author.organization, EXPECTED.authorOrganization);
+  expectEqual('book-config.json book.license', book.license, EXPECTED.bookLicense);
+  expectEqual('book-config.json book.repository.url', book.repository && book.repository.url, EXPECTED.repoUrl);
+  expectEqual('book-config.json deployment.sourceFolder', cfg.deployment && cfg.deployment.sourceFolder, 'docs');
+  expectEqual('book-config.json deployment.siteUrl', cfg.deployment && cfg.deployment.siteUrl, EXPECTED.pagesUrl);
+}
+
+function validateJekyllConfig() {
+  const cfg = parseTopLevelYaml('docs/_config.yml');
+  expectEqual('docs/_config.yml title', cfg.title, EXPECTED.title);
+  expectEqual('docs/_config.yml version', cfg.version, EXPECTED.version);
+  expectEqual('docs/_config.yml description', cfg.description, EXPECTED.description);
+  expectEqual('docs/_config.yml author', cfg.author, EXPECTED.authorName);
+  expectEqual('docs/_config.yml baseurl', cfg.baseurl, EXPECTED.baseurl);
+  expectEqual('docs/_config.yml url', trimTrailingSlash(cfg.url), EXPECTED.siteUrl);
+  expectEqual('docs/_config.yml repository', cfg.repository, EXPECTED.repoUrl);
+}
+
+function validateIndex() {
+  const { data, body } = parseFrontMatter('docs/index.md');
+  expectEqual('docs/index.md front matter title', data.title, EXPECTED.title);
+  expectEqual('docs/index.md front matter author', data.author, EXPECTED.authorName);
+  expectEqual('docs/index.md front matter version', data.version, EXPECTED.version);
+  expectEqual('docs/index.md front matter permalink', data.permalink, '/');
+  expectEqual('docs/index.md contains book description', body.includes(EXPECTED.description), true);
+
+  const allPaths = Object.values(EXPECTED_NAV).flat();
+  for (const navPath of allPaths) {
+    const relative = navPath.replace(/^\//, '');
+    if (!body.includes(`](${relative})`)) {
+      fail(`docs/index.md ToC: missing link target ${relative}`);
+    }
+  }
+}
+
+function validateNavigation() {
+  const nav = parseNavigation('docs/_data/navigation.yml');
+  for (const [section, expected] of Object.entries(EXPECTED_NAV)) {
+    expectArrayEqual(`docs/_data/navigation.yml ${section} paths`, nav[section] || [], expected);
+  }
+
+  const allPaths = Object.values(nav).flat();
+  const duplicates = allPaths.filter((item, idx) => allPaths.indexOf(item) !== idx);
+  if (duplicates.length) {
+    fail(`docs/_data/navigation.yml duplicate paths: ${JSON.stringify([...new Set(duplicates)])}`);
+  }
+
+  for (const navPath of Object.values(EXPECTED_NAV).flat()) {
+    const file = path.join('docs', navPath.replace(/^\//, ''), 'index.md');
+    expectFileExists(`navigation path ${navPath}`, file);
+  }
+}
+
+validatePackage();
+validateBookConfig();
+validateJekyllConfig();
+validateIndex();
+validateNavigation();
+
+if (errors.length) {
+  console.error('Metadata consistency check failed:');
+  for (const error of errors) console.error(`- ${error}`);
+  process.exit(1);
+}
+
+console.log('Metadata consistency check passed.');


### PR DESCRIPTION
## Summary
- Align package/book/Jekyll/front-matter version metadata to the current v1.1.0 book release.
- Add `scripts/check-metadata-consistency.js` and wire it into local `test:light` and Book QA.
- Restore a non-destructive local Jekyll build flow and scope legacy `src/**/*.md` markdownlint exceptions separately from published `docs/`.
- Add the existing afterword page to published navigation and the top-page table of contents.

## Validation
- `PUPPETEER_SKIP_DOWNLOAD=true npm ci` (completed; npm still reports existing dev/optional audit findings during install)
- `npm run check:metadata`
- `npm run test:light`
- `npm audit --omit=dev --omit=optional`
- `git diff --check`
- book-formatter Unicode, textlint/PRH, internal links, layout risk, and markdown structure checks over `docs/`
- Built-site smoke for `/`, `/afterword/`, and `/appendices/appendix-g/`
- Negative metadata fixture confirmed missing afterword navigation fails the new gate

Part of itdojp/it-engineer-knowledge-architecture#152.