### PR TITLE
Fix mobile sidebar closed state

### DIFF
--- a/docs/assets/css/mobile-responsive.css
+++ b/docs/assets/css/mobile-responsive.css
@@ -53,8 +53,21 @@ html {
     background: var(--bg-primary);
     border-right: 1px solid var(--border-color);
     box-shadow: 2px 0 8px rgba(0, 0, 0, 0.15);
-    z-index: 1000;
-    transform: translateX(-100%);
+    /*
+     * Keep the mobile drawer above the backdrop (`.book-sidebar-overlay` is
+     * 950) but below the fixed header (`.book-header` is 1000). This also
+     * needs to stay important so the later desktop `.book-sidebar` z-index in
+     * main.css cannot drop the mobile drawer behind the overlay.
+     */
+    z-index: 999 !important;
+    /*
+     * main.css imports this file before declaring the default desktop sidebar
+     * transform. Keep the closed drawer state important so the later desktop
+     * `transform: translateX(0)` rule cannot leave the TOC covering content
+     * on mobile and tablet widths. The checked/open rule below is more
+     * specific and also important, so the menu button still opens it.
+     */
+    transform: translateX(-100%) !important;
     transition: transform 0.3s ease;
   }
 


### PR DESCRIPTION
## Summary
- keep the mobile/tablet sidebar drawer off-canvas in its closed state even though `main.css` later declares the desktop `.book-sidebar { transform: translateX(0); }`
- keep the opened mobile drawer above the backdrop overlay while staying below the fixed header
- document why the mobile transform and z-index rules must be explicit in this import order

Note: `AGENTS.md` says `docs/assets/` should generally not be hand-edited. For this Issue #168 public CSS defect, the configured Pages source is `main` `/docs`, and no `mobile-responsive.css` source template exists under `templates/styles/`; therefore this PR updates the published CSS directly and keeps the change to one file.

## Validation
- `npm ci`
- `npm run check:security`
- `npm run check:metadata`
- `npm run lint:light`
- `npm run build` with workspace-local `BUNDLE_PATH`
- `git diff --check`
- local Pages visual check: `books=1 pages=10 ok=10 warn=0 fail=0`
- local direct Playwright z-index probe: 480/768/820/1024px closed drawer off-canvas; opened drawer `sidebarZ=999`, `overlayZ=950`; desktop unchanged

Part of itdojp/it-engineer-knowledge-architecture#168.
