### PR TITLE
fix: align UX flags with published modules

### DIFF
--- a/book-config.json
+++ b/book-config.json
@@ -192,13 +192,13 @@
     "profile": "B",
     "modules": {
       "quickStart": false,
-      "readingGuide": false,
-      "checklistPack": true,
+      "readingGuide": true,
+      "checklistPack": false,
       "troubleshootingFlow": true,
       "conceptMap": false,
-      "figureIndex": true,
-      "legalNotice": false,
-      "glossary": false
+      "figureIndex": false,
+      "legalNotice": true,
+      "glossary": true
     }
   },
   "shared": {


### PR DESCRIPTION
## Summary

Align UX metadata with the actual reader-facing modules audited for portfolio Sprint itdojp/it-engineer-knowledge-architecture#226.

- readingGuide: false → true (dedicated public-top section)
- checklistPack: true → false (no independent checklist pack)
- figureIndex: true → false (no dedicated figure/table index)
- legalNotice: false → true (public license section)
- glossary: false → true (Appendix A, linked in navigation)
- retain troubleshootingFlow=true for Appendix B
- track missing Profile B checklistPack / figureIndex in portal #227

## Verification

- npm ci
- npm run test:light
- npm audit --audit-level=moderate (0 vulnerabilities)
- Jekyll build
- git diff --check

Existing npm allowScripts / Faraday warnings are tracked separately in #235.

Closes #236
