### PR TITLE
feat: 独立チェックリスト集と図表索引を追加する

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Book metadata consistency check
         run: node scripts/check-metadata-consistency.js
 
+      - name: Check reader-facing checklist and figure contracts
+        run: node scripts/check-issue-240-ux.js
+
       - name: Install dependencies (book-formatter)
         working-directory: book-formatter
         run: npm ci

--- a/book-config.json
+++ b/book-config.json
@@ -193,10 +193,10 @@
     "modules": {
       "quickStart": false,
       "readingGuide": true,
-      "checklistPack": false,
+      "checklistPack": true,
       "troubleshootingFlow": true,
       "conceptMap": false,
-      "figureIndex": false,
+      "figureIndex": true,
       "legalNotice": true,
       "glossary": true
     }

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -51,6 +51,10 @@ appendices:
   path: /appendices/appendix-f/
 - title: 付録G：参考資料
   path: /appendices/appendix-g/
+- title: 独立チェックリスト集
+  path: /appendices/checklist-pack/
+- title: 図表索引
+  path: /appendices/figure-index/
 afterword:
 - title: あとがき
   path: /afterword/

--- a/docs/appendices/checklist-pack/index.md
+++ b/docs/appendices/checklist-pack/index.md
@@ -1,0 +1,57 @@
+---
+layout: book
+title: "独立チェックリスト集"
+---
+
+# 独立チェックリスト集
+
+この付録は、章内に点在する確認事項を実運用の目的別に再編したものです。各項目は未実施の確認作業として扱います。章内のコードブロックや設定例は、実施済みを示すものではありません。
+
+## 準備
+
+- [ ] 対象リポジトリ、責任者、利用するGitHubアカウントまたは組織を確認した。根拠: [第1章](../../chapters/chapter01/)、[第5章](../../chapters/chapter05/)
+- [ ] Gitのユーザー設定、認証方法、必要な開発環境をプロジェクトのルールに合わせた。根拠: [第3章](../../chapters/chapter03/)
+- [ ] 機密情報、学習データ、ライセンスの扱いを公開前に確認した。根拠: [第5章](../../chapters/chapter05/)、[第17章](../../chapters/chapter17/)、[付録G](../appendix-g/)
+
+## Issue と計画
+
+- [ ] Issueに目的、受入基準、制約、変更禁止領域を記録した。根拠: [第2章](../../chapters/chapter02/)、[第4章](../../chapters/chapter04/)
+- [ ] 影響範囲、検証方法、ロールバック方針を作業開始前に合意した。根拠: [第2章](../../chapters/chapter02/)、[第11章](../../chapters/chapter11/)
+- [ ] AI支援を使う場合は、入力可能な情報と人間の確認責任を明確にした。根拠: [第2章](../../chapters/chapter02/)、[第6章](../../chapters/chapter06/)
+
+## ブランチとコミット
+
+- [ ] 変更目的に対応する短命ブランチを作成し、mainへの直接変更を避けた。根拠: [第1章](../../chapters/chapter01/)、[第12章](../../chapters/chapter12/)
+- [ ] コミットをレビュー可能な単位に分け、意図と検証結果を説明できる状態にした。根拠: [第1章](../../chapters/chapter01/)、[第3章](../../chapters/chapter03/)
+- [ ] 実験、release、不要になったブランチの扱いをチームで定義した。根拠: [第12章](../../chapters/chapter12/)
+
+## Pull Request とレビュー
+
+- [ ] PRに変更内容、影響範囲、検証、ロールバック、AI利用の有無を記載した。根拠: [第2章](../../chapters/chapter02/)、[第7章](../../chapters/chapter07/)
+- [ ] 人間が仕様、リスク、セキュリティ上の判断を確認し、AIレビューだけで承認しない。根拠: [第7章](../../chapters/chapter07/)
+- [ ] CODEOWNERS、必須レビュアー、承認条件が対象変更に適用されることを確認した。根拠: [第9章](../../chapters/chapter09/)
+
+## CI/CD
+
+- [ ] 必須テスト、静的解析、依存関係確認をPRの品質ゲートとして実行した。根拠: [第7章](../../chapters/chapter07/)、[第13章](../../chapters/chapter13/)
+- [ ] デプロイ対象環境、承認者、Secretsの参照範囲を確認した。根拠: [第11章](../../chapters/chapter11/)、[第13章](../../chapters/chapter13/)
+- [ ] 失敗時の停止、再実行、ロールバックの手順を検証可能な形で残した。根拠: [第11章](../../chapters/chapter11/)、[付録B](../appendix-b/)
+
+## セキュリティ
+
+- [ ] トークン、パスワード、個人情報、機密データをコード、ログ、Issue、PRへ含めていない。根拠: [第8章](../../chapters/chapter08/)、[第11章](../../chapters/chapter11/)
+- [ ] 入力検証、認証・認可、依存関係更新、破壊的変更のリスクを確認した。根拠: [第7章](../../chapters/chapter07/)、[第8章](../../chapters/chapter08/)
+- [ ] Secret scanning、code scanning、dependency reviewの結果を確認し、例外があれば記録した。根拠: [第8章](../../chapters/chapter08/)
+
+## 組織・大規模運用
+
+- [ ] 組織、チーム、リポジトリの権限継承と直接付与を監査した。根拠: [第9章](../../chapters/chapter09/)、[第10章](../../chapters/chapter10/)
+- [ ] Outside Collaborator、SAML SSO、監査ログの運用を組織ポリシーと照合した。根拠: [第10章](../../chapters/chapter10/)
+- [ ] 大規模データ、モデル、外部協力者、コンプライアンスの責任分界を確認した。根拠: [第14章](../../chapters/chapter14/)、[第16章](../../chapters/chapter16/)、[第17章](../../chapters/chapter17/)
+
+## 関連資料
+
+次の資料はリポジトリ内の導入例であり、この公開チェックリストの実施済み項目ではありません。対象リポジトリの公開範囲と運用文脈を確認したうえで参照してください。
+
+- <https://github.com/itdojp/github-workflow-book/blob/main/examples/ai-agent-starter/security-checklist.md> — AIエージェント向けSecurity checklist: AIレビューの見落としを前提に人間が確認する最小例。
+- <https://github.com/itdojp/github-workflow-book/blob/main/examples/self-hosted-runner-ops-checklist/README.md> — self-hosted runner運用チェックリスト: trusted input、runner分離、ephemeral運用を扱う導入例。

--- a/docs/appendices/figure-index/index.md
+++ b/docs/appendices/figure-index/index.md
@@ -1,0 +1,16 @@
+---
+layout: book
+title: "図表索引"
+---
+
+# 図表索引
+
+この索引は、本書の公開本文に掲載する自己完結SVG図版のexact inventoryです。スクリーンショット用コード例、badge、favicon、logoは含めません。
+
+1. [図1.1：ローカルとリモートの同期](../../chapters/chapter01/#figure-chapter01-repository-sync) — 作業ディレクトリ、ステージング、ローカルリポジトリ、GitHubの同期。
+2. [図5.1：Public / Privateリポジトリの判断フロー](../../chapters/chapter05/#figure-chapter05-repository-visibility) — 公開制約と公開目的に基づく可視性の選択。
+3. [図7.1：ハイブリッドレビューワークフロー](../../chapters/chapter07/#figure-chapter07-hybrid-review-flow) — AIレビュー、人間レビュー、CIの品質ゲート。
+4. [図9.1：組織からリポジトリへの権限継承](../../chapters/chapter09/#figure-chapter09-permission-inheritance) — Organization、Team、Repositoryの権限経路。
+5. [図12.1：ML開発向けGit Flow](../../chapters/chapter12/#figure-chapter12-ml-git-flow) — feature、experiment、releaseを含む統合フロー。
+
+各リンクは該当する`figure`要素のstable anchorへ直接移動します。図版はJavaScriptを必要とせず、SVG内のtitleと説明、captionを備えます。

--- a/docs/assets/css/main.css
+++ b/docs/assets/css/main.css
@@ -382,6 +382,23 @@ a:hover {
     height: auto;
 }
 
+.book-figure {
+    margin: 1.5rem 0;
+}
+
+@media (max-width: 640px) {
+    .book-figure:not(.book-figure--narrow) {
+        overflow-x: auto;
+        overscroll-behavior-inline: contain;
+        padding-bottom: 0.5rem;
+    }
+
+    .book-figure:not(.book-figure--narrow) > svg {
+        min-width: 720px;
+        max-width: none !important;
+    }
+}
+
 .page-content table {
     width: 100%;
     border-collapse: collapse;

--- a/docs/chapters/chapter01/index.md
+++ b/docs/chapters/chapter01/index.md
@@ -149,17 +149,22 @@ main
 
 ### 同期の仕組み
 
-```mermaid
-graph LR
-    A[作業ディレクトリ] -->|add| B[ステージングエリア]
-    B -->|commit| C[ローカルリポジトリ]
-    C <-->|push/pull| D[リモートリポジトリ<br/>GitHub]
-    
-    style A fill:#f9f9f9,stroke:#333,stroke-width:2px
-    style B fill:#e1f5e1,stroke:#333,stroke-width:2px
-    style C fill:#e1e5f5,stroke:#333,stroke-width:2px
-    style D fill:#ffe1e1,stroke:#333,stroke-width:2px
-```
+<figure id="figure-chapter01-repository-sync" class="book-figure">
+  <svg style="display: block; max-width: 100%; height: auto; margin: 0 auto;" viewBox="0 0 960 260" width="960" height="260" role="img" aria-labelledby="figure-chapter01-repository-sync-title figure-chapter01-repository-sync-desc" xmlns="http://www.w3.org/2000/svg">
+    <title id="figure-chapter01-repository-sync-title">ローカルとリモートの同期</title>
+    <desc id="figure-chapter01-repository-sync-desc">作業ディレクトリからステージングエリア、ローカルリポジトリへ進み、ローカルリポジトリとGitHub上のリモートリポジトリをpushとpullで双方向に同期する流れ。</desc>
+    <defs><marker id="sync-arrow" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto"><path d="M0,0 L10,4 L0,8 Z" fill="#1f2937"/></marker></defs>
+    <style>.sync-box{stroke:#1f2937;stroke-width:3}.sync-text{fill:#111827;font:600 18px sans-serif}.sync-label{fill:#111827;font:16px sans-serif}.sync-line{stroke:#1f2937;stroke-width:3;marker-end:url(#sync-arrow)}</style>
+    <rect class="sync-box" x="25" y="80" width="180" height="80" rx="10" fill="#f9fafb"/><text class="sync-text" x="115" y="112" text-anchor="middle">作業</text><text class="sync-text" x="115" y="137" text-anchor="middle">ディレクトリ</text>
+    <rect class="sync-box" x="270" y="80" width="180" height="80" rx="10" fill="#dcfce7"/><text class="sync-text" x="360" y="123" text-anchor="middle">ステージングエリア</text>
+    <rect class="sync-box" x="515" y="80" width="180" height="80" rx="10" fill="#dbeafe"/><text class="sync-text" x="605" y="112" text-anchor="middle">ローカル</text><text class="sync-text" x="605" y="137" text-anchor="middle">リポジトリ</text>
+    <rect class="sync-box" x="760" y="70" width="175" height="100" rx="10" fill="#fee2e2"/><text class="sync-text" x="847" y="101" text-anchor="middle">リモート</text><text class="sync-text" x="847" y="126" text-anchor="middle">リポジトリ</text><text class="sync-label" x="847" y="150" text-anchor="middle">（GitHub）</text>
+    <line class="sync-line" x1="205" y1="120" x2="260" y2="120"/><text class="sync-label" x="232" y="68" text-anchor="middle">add</text>
+    <line class="sync-line" x1="450" y1="120" x2="505" y2="120"/><text class="sync-label" x="477" y="68" text-anchor="middle">commit</text>
+    <line class="sync-line" x1="695" y1="105" x2="750" y2="105"/><line class="sync-line" x1="760" y1="140" x2="705" y2="140"/><text class="sync-label" x="727" y="68" text-anchor="middle">push</text><text class="sync-label" x="727" y="190" text-anchor="middle">pull</text>
+  </svg>
+  <figcaption>図1.1：ローカル作業からGitHub上のリモートリポジトリまでの同期。矢印のラベルは実行するGit操作を示す。</figcaption>
+</figure>
 
 ### リモートブランチの追跡
 - ローカルブランチとリモートブランチの対応

--- a/docs/chapters/chapter05/index.md
+++ b/docs/chapters/chapter05/index.md
@@ -152,30 +152,34 @@ policies:
 
 ### AI協働を含む判断フローチャート
 
-```mermaid
-flowchart TD
-    A[リポジトリ作成] --> B{機密情報を含むか？}
-    B -->|Yes| C[Private]
-    B -->|No| D{AI生成コードの<br/>知的財産権が懸念されるか？}
-    D -->|Yes| E[Private + AI使用ポリシー明記]
-    D -->|No| F{特許や独自アルゴリズムを含むか？}
-    F -->|Yes| G[Private]
-    F -->|No| H{オープンソースとして<br/>公開する意図があるか？}
-    H -->|Yes| I[Public + AI協働の明示]
-    H -->|No| J{AI協働の学習事例として<br/>共有したいか？}
-    J -->|Yes| K[Public + AI協働ドキュメント]
-    J -->|No| L{教育目的や<br/>ポートフォリオか？}
-    L -->|Yes| M[Public]
-    L -->|No| N[Private]
-    
-    style C fill:#ffcccc
-    style E fill:#ffcccc
-    style G fill:#ffcccc
-    style N fill:#ffcccc
-    style I fill:#ccffcc
-    style K fill:#ccffcc
-    style M fill:#ccffcc
-```
+<figure id="figure-chapter05-repository-visibility" class="book-figure">
+  <svg style="display: block; max-width: 100%; height: auto; margin: 0 auto;" viewBox="0 0 760 900" width="760" height="900" role="img" aria-labelledby="figure-chapter05-repository-visibility-title figure-chapter05-repository-visibility-desc" xmlns="http://www.w3.org/2000/svg">
+    <title id="figure-chapter05-repository-visibility-title">PublicとPrivateリポジトリの判断</title>
+    <desc id="figure-chapter05-repository-visibility-desc">機密情報、AI生成コードの知的財産権、特許・独自アルゴリズム、オープンソース公開の意図、AI協働の学習事例共有、教育・ポートフォリオの順に確認する。各質問のはい側でPrivateまたは目的別のPublicを選び、すべていいえの場合はPrivateを選ぶ判断フロー。</desc>
+    <defs><marker id="visibility-arrow" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto"><path d="M0,0 L10,4 L0,8 Z" fill="#1f2937"/></marker></defs>
+    <style>.visibility-node{stroke:#1f2937;stroke-width:3}.visibility-text{fill:#111827;font:600 17px sans-serif}.visibility-small{fill:#111827;font:15px sans-serif}.visibility-line{fill:none;stroke:#1f2937;stroke-width:3;marker-end:url(#visibility-arrow)}.visibility-answer{fill:#111827;font:600 15px sans-serif}</style>
+    <rect class="visibility-node" x="270" y="15" width="220" height="54" rx="10" fill="#e0f2fe"/><text class="visibility-text" x="380" y="49" text-anchor="middle">リポジトリ作成</text>
+    <polygon class="visibility-node" points="380,88 570,133 380,178 190,133" fill="#fef3c7"/><text class="visibility-text" x="380" y="139" text-anchor="middle">機密情報を含むか？</text>
+    <rect class="visibility-node" x="20" y="105" width="140" height="56" rx="10" fill="#fee2e2"/><text class="visibility-text" x="90" y="140" text-anchor="middle">Private</text><path class="visibility-line" d="M190 133 H170"/><text class="visibility-answer" x="170" y="98" text-anchor="middle">はい</text>
+    <path class="visibility-line" d="M380 178 V203"/><text class="visibility-answer" x="397" y="197">いいえ</text>
+    <polygon class="visibility-node" points="380,210 590,262 380,314 170,262" fill="#fef3c7"/><text class="visibility-text" x="380" y="254" text-anchor="middle">AI生成コードの知的財産権が</text><text class="visibility-text" x="380" y="278" text-anchor="middle">懸念されるか？</text>
+    <rect class="visibility-node" x="5" y="230" width="150" height="64" rx="10" fill="#fee2e2"/><text class="visibility-small" x="80" y="256" text-anchor="middle">Private＋</text><text class="visibility-small" x="80" y="278" text-anchor="middle">AI使用ポリシー</text><path class="visibility-line" d="M170 262 H165"/><text class="visibility-answer" x="165" y="222" text-anchor="middle">はい</text>
+    <path class="visibility-line" d="M380 314 V339"/><text class="visibility-answer" x="397" y="333">いいえ</text>
+    <polygon class="visibility-node" points="380,346 580,394 380,442 180,394" fill="#fef3c7"/><text class="visibility-text" x="380" y="387" text-anchor="middle">特許や独自アルゴリズムを</text><text class="visibility-text" x="380" y="411" text-anchor="middle">含むか？</text>
+    <rect class="visibility-node" x="20" y="366" width="140" height="56" rx="10" fill="#fee2e2"/><text class="visibility-text" x="90" y="401" text-anchor="middle">Private</text><path class="visibility-line" d="M180 394 H170"/><text class="visibility-answer" x="170" y="354" text-anchor="middle">はい</text>
+    <path class="visibility-line" d="M380 442 V467"/><text class="visibility-answer" x="397" y="461">いいえ</text>
+    <polygon class="visibility-node" points="380,474 580,522 380,570 180,522" fill="#fef3c7"/><text class="visibility-text" x="380" y="515" text-anchor="middle">オープンソースとして</text><text class="visibility-text" x="380" y="539" text-anchor="middle">公開する意図があるか？</text>
+    <rect class="visibility-node" x="600" y="490" width="150" height="64" rx="10" fill="#dcfce7"/><text class="visibility-small" x="675" y="516" text-anchor="middle">Public＋</text><text class="visibility-small" x="675" y="538" text-anchor="middle">AI協働の明示</text><path class="visibility-line" d="M580 522 H590"/><text class="visibility-answer" x="590" y="480" text-anchor="middle">はい</text>
+    <path class="visibility-line" d="M380 570 V595"/><text class="visibility-answer" x="397" y="589">いいえ</text>
+    <polygon class="visibility-node" points="380,602 580,650 380,698 180,650" fill="#fef3c7"/><text class="visibility-text" x="380" y="643" text-anchor="middle">AI協働の学習事例として</text><text class="visibility-text" x="380" y="667" text-anchor="middle">共有したいか？</text>
+    <rect class="visibility-node" x="600" y="618" width="150" height="64" rx="10" fill="#dcfce7"/><text class="visibility-small" x="675" y="644" text-anchor="middle">Public＋</text><text class="visibility-small" x="675" y="666" text-anchor="middle">AI協働文書</text><path class="visibility-line" d="M580 650 H590"/><text class="visibility-answer" x="590" y="608" text-anchor="middle">はい</text>
+    <path class="visibility-line" d="M380 698 V723"/><text class="visibility-answer" x="397" y="717">いいえ</text>
+    <polygon class="visibility-node" points="380,730 570,775 380,820 190,775" fill="#fef3c7"/><text class="visibility-text" x="380" y="768" text-anchor="middle">教育目的または</text><text class="visibility-text" x="380" y="792" text-anchor="middle">ポートフォリオか？</text>
+    <rect class="visibility-node" x="600" y="747" width="140" height="56" rx="10" fill="#dcfce7"/><text class="visibility-text" x="670" y="782" text-anchor="middle">Public</text><path class="visibility-line" d="M570 775 H590"/><text class="visibility-answer" x="590" y="736" text-anchor="middle">はい</text>
+    <path class="visibility-line" d="M380 820 V844"/><text class="visibility-answer" x="397" y="839">いいえ</text><rect class="visibility-node" x="310" y="844" width="140" height="50" rx="10" fill="#fee2e2"/><text class="visibility-text" x="380" y="876" text-anchor="middle">Private</text>
+  </svg>
+  <figcaption>図5.1：Public / Private リポジトリの判断フロー。機密性、知的財産、公開意図、共有・教育目的を順に確認し、公開時はAI協働の方針を明示する。</figcaption>
+</figure>
 
 ### Publicリポジトリの利点
 - **コミュニティ貢献**: オープンソースエコシステムへの参加

--- a/docs/chapters/chapter07/index.md
+++ b/docs/chapters/chapter07/index.md
@@ -236,15 +236,23 @@ def calculate_metrics(y_true, y_pred, threshold=0.5):
 
 ### ハイブリッドレビューワークフロー
 
-```mermaid
-graph LR
-    A[PR作成] --> B[（任意）Copilot code review]
-    B --> C[人間レビュー（仕様/リスク判断）]
-    C --> D[CI（テスト/静的解析）]
-    D --> E{要修正?}
-    E -->|Yes| F[修正→再レビュー]
-    E -->|No| G[承認→マージ]
-```
+<figure id="figure-chapter07-hybrid-review-flow" class="book-figure">
+  <svg style="display: block; max-width: 100%; height: auto; margin: 0 auto;" viewBox="0 0 1080 300" width="1080" height="300" role="img" aria-labelledby="figure-chapter07-hybrid-review-flow-title figure-chapter07-hybrid-review-flow-desc" xmlns="http://www.w3.org/2000/svg">
+    <title id="figure-chapter07-hybrid-review-flow-title">ハイブリッドレビューワークフロー</title>
+    <desc id="figure-chapter07-hybrid-review-flow-desc">PR作成後、任意のAIレビュー、人間による仕様とリスクのレビュー、CIを順番に実施する。要修正なら修正と再レビューへ戻り、不要なら承認してマージする。</desc>
+    <defs><marker id="review-arrow" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto"><path d="M0,0 L10,4 L0,8 Z" fill="#1f2937"/></marker></defs>
+    <style>.review-box{stroke:#1f2937;stroke-width:3}.review-text{fill:#111827;font:600 16px sans-serif}.review-label{fill:#111827;font:15px sans-serif}.review-line{fill:none;stroke:#1f2937;stroke-width:3;marker-end:url(#review-arrow)}</style>
+    <rect class="review-box" x="20" y="105" width="145" height="60" rx="10" fill="#e0f2fe"/><text class="review-text" x="92" y="141" text-anchor="middle">PR作成</text>
+    <rect class="review-box" x="205" y="90" width="185" height="90" rx="10" fill="#ede9fe"/><text class="review-text" x="297" y="125" text-anchor="middle">任意：AIレビュー</text><text class="review-label" x="297" y="151" text-anchor="middle">Copilot code review</text>
+    <rect class="review-box" x="430" y="90" width="195" height="90" rx="10" fill="#fef3c7"/><text class="review-text" x="527" y="125" text-anchor="middle">人間レビュー</text><text class="review-label" x="527" y="151" text-anchor="middle">仕様・リスク判断</text>
+    <rect class="review-box" x="665" y="90" width="145" height="90" rx="10" fill="#dbeafe"/><text class="review-text" x="737" y="125" text-anchor="middle">CI</text><text class="review-label" x="737" y="151" text-anchor="middle">テスト・静的解析</text>
+    <polygon class="review-box" points="900,90 980,135 900,180 820,135" fill="#fef3c7"/><text class="review-text" x="900" y="141" text-anchor="middle">要修正？</text>
+    <rect class="review-box" x="855" y="225" width="180" height="55" rx="10" fill="#fee2e2"/><text class="review-text" x="945" y="259" text-anchor="middle">修正・再レビュー</text>
+    <rect class="review-box" x="850" y="20" width="185" height="50" rx="10" fill="#dcfce7"/><text class="review-text" x="942" y="52" text-anchor="middle">承認・マージ</text>
+    <path class="review-line" d="M165 135 H195"/><path class="review-line" d="M390 135 H420"/><path class="review-line" d="M625 135 H655"/><path class="review-line" d="M810 135 H820"/><path class="review-line" d="M900 90 V70"/><text class="review-label" x="918" y="86">いいえ</text><path class="review-line" d="M900 180 V225"/><text class="review-label" x="918" y="205">はい</text><path class="review-line" d="M855 252 H527 V180"/>
+  </svg>
+  <figcaption>図7.1：AIレビューを補助として使い、人間の仕様・リスク判断とCIを必須の品質ゲートとして組み合わせるハイブリッドレビュー。</figcaption>
+</figure>
 
 ### レビュー優先順位の設定
 

--- a/docs/chapters/chapter09/index.md
+++ b/docs/chapters/chapter09/index.md
@@ -630,18 +630,22 @@ class ReviewBot:
 ### 組織からリポジトリへの権限継承
 
 #### 継承の仕組み
-```mermaid
-graph TD
-    A[Organization Owner] --> B[Organization Member]
-    B --> C[Team Member]
-    C --> D[Repository Access]
-    
-    A --> E[Direct Repository Admin]
-    E --> D
-    
-    C --> F[Team Repository Permission]
-    F --> D
-```
+<figure id="figure-chapter09-permission-inheritance" class="book-figure">
+  <svg style="display: block; max-width: 100%; height: auto; margin: 0 auto;" viewBox="0 0 920 420" width="920" height="420" role="img" aria-labelledby="figure-chapter09-permission-inheritance-title figure-chapter09-permission-inheritance-desc" xmlns="http://www.w3.org/2000/svg">
+    <title id="figure-chapter09-permission-inheritance-title">組織からリポジトリへの権限継承</title>
+    <desc id="figure-chapter09-permission-inheritance-desc">Organization OwnerからOrganization Member、Team Member、Repository Accessへ継承する経路と、直接のRepository AdminおよびTeam Repository PermissionからRepository Accessへ到達する経路。</desc>
+    <defs><marker id="permission-arrow" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto"><path d="M0,0 L10,4 L0,8 Z" fill="#1f2937"/></marker></defs>
+    <style>.permission-box{stroke:#1f2937;stroke-width:3}.permission-text{fill:#111827;font:600 17px sans-serif}.permission-line{fill:none;stroke:#1f2937;stroke-width:3;marker-end:url(#permission-arrow)}</style>
+    <rect class="permission-box" x="350" y="20" width="220" height="60" rx="10" fill="#e0f2fe"/><text class="permission-text" x="460" y="57" text-anchor="middle">Organization Owner</text>
+    <rect class="permission-box" x="350" y="125" width="220" height="60" rx="10" fill="#dbeafe"/><text class="permission-text" x="460" y="162" text-anchor="middle">Organization Member</text>
+    <rect class="permission-box" x="350" y="230" width="220" height="60" rx="10" fill="#ede9fe"/><text class="permission-text" x="460" y="267" text-anchor="middle">Team Member</text>
+    <rect class="permission-box" x="40" y="230" width="230" height="60" rx="10" fill="#fef3c7"/><text class="permission-text" x="155" y="267" text-anchor="middle">Direct Repository Admin</text>
+    <rect class="permission-box" x="650" y="225" width="230" height="75" rx="10" fill="#fef3c7"/><text class="permission-text" x="765" y="257" text-anchor="middle">Team Repository</text><text class="permission-text" x="765" y="281" text-anchor="middle">Permission</text>
+    <rect class="permission-box" x="335" y="345" width="250" height="60" rx="10" fill="#dcfce7"/><text class="permission-text" x="460" y="382" text-anchor="middle">Repository Access</text>
+    <path class="permission-line" d="M460 80 V115"/><path class="permission-line" d="M460 185 V220"/><path class="permission-line" d="M460 290 V335"/><path class="permission-line" d="M395 80 C260 110,155 150,155 220"/><path class="permission-line" d="M570 260 H650"/><path class="permission-line" d="M155 290 C155 325,300 355,325 365"/><path class="permission-line" d="M765 300 C765 325,620 355,595 365"/>
+  </svg>
+  <figcaption>図9.1：組織、チーム、直接付与の経路からリポジトリ権限へ至る関係。実効権限は組織ポリシーとリポジトリ設定も併せて確認する。</figcaption>
+</figure>
 
 ### 権限の優先順位
 

--- a/docs/chapters/chapter12/index.md
+++ b/docs/chapters/chapter12/index.md
@@ -136,43 +136,22 @@ image-classification/
 - `hotfix/<short>`（本番障害対応。第11章とセット）
 
 #### ML開発向けGit Flow
-```mermaid
-gitGraph
-    commit id: "Initial"
-    branch develop
-    checkout develop
-    commit id: "Setup"
-    
-    branch feature/data-pipeline
-    checkout feature/data-pipeline
-    commit id: "Add loader"
-    commit id: "Add augmentation"
-    checkout develop
-    merge feature/data-pipeline
-    
-    branch experiment/resnet50
-    checkout experiment/resnet50
-    commit id: "ResNet50 base"
-    commit id: "Tune hyperparams"
-    
-    branch experiment/efficientnet
-    checkout experiment/efficientnet
-    commit id: "EfficientNet base"
-    commit id: "Optimize"
-    
-    checkout develop
-    merge experiment/resnet50
-    
-    branch release/v1.0
-    checkout release/v1.0
-    commit id: "Prepare release"
-    
-    checkout main
-    merge release/v1.0 tag: "v1.0"
-    
-    checkout develop
-    merge release/v1.0
-```
+<figure id="figure-chapter12-ml-git-flow" class="book-figure book-figure--narrow">
+  <svg style="display: block; max-width: 100%; height: auto; margin: 0 auto;" viewBox="0 0 360 650" width="360" height="650" role="img" aria-labelledby="figure-chapter12-ml-git-flow-title figure-chapter12-ml-git-flow-desc" xmlns="http://www.w3.org/2000/svg">
+    <title id="figure-chapter12-ml-git-flow-title">ML開発向けGit Flow</title>
+    <desc id="figure-chapter12-ml-git-flow-desc">mainからdevelopを作成する。data pipelineのfeatureブランチ、ResNet50とEfficientNetのexperimentブランチをdevelopから分岐する。採用した実験をdevelopへ統合し、release v1.0をmainへマージしてタグ付けし、developへ戻す流れ。</desc>
+    <defs><marker id="gitflow-arrow" markerWidth="8" markerHeight="7" refX="7" refY="3.5" orient="auto"><path d="M0,0 L8,3.5 L0,7 Z" fill="#1f2937"/></marker></defs>
+    <style>.gitflow-line{stroke-width:4;fill:none}.gitflow-main{stroke:#1d4ed8}.gitflow-dev{stroke:#047857}.gitflow-feature{stroke:#7c3aed}.gitflow-experiment{stroke:#c2410c}.gitflow-release{stroke:#be123c}.gitflow-dot{stroke:#111827;stroke-width:1.5}.gitflow-text{fill:#111827;font:600 14px sans-serif}.gitflow-note{fill:#111827;font:12px sans-serif}.gitflow-merge{fill:none;stroke:#1f2937;stroke-width:2.5;marker-end:url(#gitflow-arrow)}</style>
+    <text class="gitflow-text" x="12" y="65">main</text><path class="gitflow-line gitflow-main" d="M125 60 H335"/><circle class="gitflow-dot" cx="145" cy="60" r="6" fill="#1d4ed8"/><circle class="gitflow-dot" cx="315" cy="60" r="6" fill="#1d4ed8"/><text class="gitflow-note" x="132" y="43">Initial</text><text class="gitflow-note" x="300" y="43">v1.0</text>
+    <text class="gitflow-text" x="12" y="145">develop</text><path class="gitflow-line gitflow-dev" d="M125 140 H335"/><circle class="gitflow-dot" cx="145" cy="140" r="6" fill="#047857"/><circle class="gitflow-dot" cx="245" cy="140" r="6" fill="#047857"/><circle class="gitflow-dot" cx="315" cy="140" r="6" fill="#047857"/><text class="gitflow-note" x="132" y="123">Setup</text>
+    <text class="gitflow-text" x="12" y="225">feature/</text><text class="gitflow-text" x="12" y="243">data-pipeline</text><path class="gitflow-line gitflow-feature" d="M125 230 H235"/><circle class="gitflow-dot" cx="160" cy="230" r="6" fill="#7c3aed"/><circle class="gitflow-dot" cx="215" cy="230" r="6" fill="#7c3aed"/><text class="gitflow-note" x="142" y="258">loader・augmentation</text>
+    <text class="gitflow-text" x="12" y="325">experiment/</text><text class="gitflow-text" x="12" y="343">resnet50</text><path class="gitflow-line gitflow-experiment" d="M125 330 H235"/><circle class="gitflow-dot" cx="160" cy="330" r="6" fill="#c2410c"/><circle class="gitflow-dot" cx="215" cy="330" r="6" fill="#c2410c"/><text class="gitflow-note" x="138" y="358">base・tuning</text>
+    <text class="gitflow-text" x="12" y="425">experiment/</text><text class="gitflow-text" x="12" y="443">efficientnet</text><path class="gitflow-line gitflow-experiment" d="M125 430 H235"/><circle class="gitflow-dot" cx="160" cy="430" r="6" fill="#c2410c"/><circle class="gitflow-dot" cx="215" cy="430" r="6" fill="#c2410c"/><text class="gitflow-note" x="138" y="458">base・optimize</text>
+    <text class="gitflow-text" x="12" y="525">release/</text><text class="gitflow-text" x="12" y="543">v1.0</text><path class="gitflow-line gitflow-release" d="M125 530 H235"/><circle class="gitflow-dot" cx="180" cy="530" r="6" fill="#be123c"/><text class="gitflow-note" x="142" y="558">Prepare release</text>
+    <path class="gitflow-merge" d="M145 140 V220 H125"/><path class="gitflow-merge" d="M145 140 V320 H125"/><path class="gitflow-merge" d="M145 140 V420 H125"/><path class="gitflow-merge" d="M235 230 V140 H245"/><path class="gitflow-merge" d="M235 330 V140 H245"/><path class="gitflow-merge" d="M245 140 V520 H125"/><path class="gitflow-merge" d="M235 530 V60 H315"/><path class="gitflow-merge" d="M235 530 V140 H315"/>
+  </svg>
+  <figcaption>図12.1：ML開発向けGit Flow。実験ブランチをdevelopから分岐し、採用した実験だけを統合してrelease経由でmainへリリースする。</figcaption>
+</figure>
 
 ### rulesets と merge queue を前提にした統制
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -195,6 +195,8 @@ ChatGPT/GitHub Copilot/Claude等のAI開発者ツールとGitHubを統合した�
 #### [付録E：便利なGitエイリアス集](appendices/appendix-e/)
 #### [付録F：推奨VS Code拡張機能](appendices/appendix-f/)
 #### [付録G：参考資料](appendices/appendix-g/)
+#### [独立チェックリスト集](appendices/checklist-pack/)
+#### [図表索引](appendices/figure-index/)
 
 ### あとがき
 

--- a/package.json
+++ b/package.json
@@ -19,11 +19,12 @@
     "deploy": "bash scripts/deploy.sh",
     "clean": "rm -rf _site public output temp",
     "lint:light": "markdownlint --config .markdownlint-src.json 'src/**/*.md' --ignore node_modules",
-    "test:light": "npm run check:security && npm run check:metadata && npm run lint:light && npm run build",
+    "test:light": "npm run check:security && npm run check:metadata && npm run check:issue-240-ux && npm run lint:light && npm run build",
     "help": "echo 'Available commands:\n  npm run setup - Interactive setup\n  npm run build - Build the book\n  npm run preview - Local preview\n  npm run deploy - Deploy to GitHub Pages'",
     "build:generate": "node scripts/build-simple.js",
     "check:metadata": "node scripts/check-metadata-consistency.js",
-    "check:security": "npm audit"
+    "check:security": "npm audit",
+    "check:issue-240-ux": "node scripts/check-issue-240-ux.js"
   },
   "dependencies": {
     "fs-extra": "^11.3.5",

--- a/scripts/check-issue-240-ux.js
+++ b/scripts/check-issue-240-ux.js
@@ -20,7 +20,12 @@ const expect = (condition, message) => { if (!condition) errors.push(message); }
 const normalize = (content) => content.replace(/\r\n/g, '\n');
 const stripFrontMatter = (content) => normalize(content).replace(/^---\n[\s\S]*?\n---\n/, '');
 
-const config = JSON.parse(read('book-config.json'));
+let config = {};
+try {
+  config = JSON.parse(read('book-config.json'));
+} catch (error) {
+  errors.push(`book-config.json: JSON parse failed (${error.message})`);
+}
 expect(config.ux?.modules?.checklistPack === true, 'book-config.json: checklistPack must be true');
 expect(config.ux?.modules?.figureIndex === true, 'book-config.json: figureIndex must be true');
 
@@ -94,9 +99,14 @@ expect(checklistItems.every((item) => item.includes('根拠:') && /\.\.\/\.\.\/c
 expect(publicChecklist.includes('実施済み項目ではありません'),
   'checklist pack must distinguish repository examples from completed checks');
 
-const css = read('docs/assets/css/main.css');
-expect(css.includes('.book-figure:not(.book-figure--narrow)') && css.includes('min-width: 720px'),
-  'mobile figure CSS must preserve text readability with a horizontal scroll viewport');
+const hasMobileFigureCss = (content) =>
+  content.includes('.book-figure:not(.book-figure--narrow)') && content.includes('min-width: 720px');
+const publicCss = read('docs/assets/css/main.css');
+const sourceCss = read('templates/styles/main.css');
+expect(hasMobileFigureCss(publicCss),
+  'public mobile figure CSS must preserve text readability with a horizontal scroll viewport');
+expect(hasMobileFigureCss(sourceCss),
+  'generated stylesheet source must preserve the mobile figure horizontal scroll contract');
 const workflow = read('.github/workflows/book-qa.yml');
 expect(workflow.includes('node scripts/check-issue-240-ux.js'),
   'Book QA must execute the Issue #240 UX contract');

--- a/scripts/check-issue-240-ux.js
+++ b/scripts/check-issue-240-ux.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+const errors = [];
+const routes = ['/appendices/checklist-pack/', '/appendices/figure-index/'];
+const figures = [
+  ['chapter01', 'figure-chapter01-repository-sync', '図1.1：ローカルとリモートの同期'],
+  ['chapter05', 'figure-chapter05-repository-visibility', '図5.1：Public / Privateリポジトリの判断フロー'],
+  ['chapter07', 'figure-chapter07-hybrid-review-flow', '図7.1：ハイブリッドレビューワークフロー'],
+  ['chapter09', 'figure-chapter09-permission-inheritance', '図9.1：組織からリポジトリへの権限継承'],
+  ['chapter12', 'figure-chapter12-ml-git-flow', '図12.1：ML開発向けGit Flow']
+];
+
+const read = (file) => {
+  try { return fs.readFileSync(file, 'utf8'); }
+  catch (error) { errors.push(`${file}: read failed (${error.message})`); return ''; }
+};
+const expect = (condition, message) => { if (!condition) errors.push(message); };
+const normalize = (content) => content.replace(/\r\n/g, '\n');
+const stripFrontMatter = (content) => normalize(content).replace(/^---\n[\s\S]*?\n---\n/, '');
+
+const config = JSON.parse(read('book-config.json'));
+expect(config.ux?.modules?.checklistPack === true, 'book-config.json: checklistPack must be true');
+expect(config.ux?.modules?.figureIndex === true, 'book-config.json: figureIndex must be true');
+
+const navigation = read('docs/_data/navigation.yml');
+const top = read('docs/index.md');
+for (const route of routes) {
+  expect(fs.existsSync(path.join('docs', route.slice(1), 'index.md')), `missing public canonical route ${route}`);
+  expect(fs.existsSync(path.join('src', route.slice(1), 'index.md')), `missing source canonical route ${route}`);
+  expect(navigation.includes(`path: ${route}`), `navigation is missing ${route}`);
+  expect(top.includes(`](${route.slice(1)})`), `top page is missing ${route}`);
+}
+const appendixG = navigation.indexOf('path: /appendices/appendix-g/');
+const checklist = navigation.indexOf('path: /appendices/checklist-pack/');
+const figureIndexRoute = navigation.indexOf('path: /appendices/figure-index/');
+const afterword = navigation.indexOf('afterword:');
+expect(appendixG >= 0 && appendixG < checklist && checklist < figureIndexRoute && figureIndexRoute < afterword,
+  'new routes must follow appendix G and precede afterword');
+expect((navigation.match(/path: \/appendices\/checklist-pack\//g) || []).length === 1,
+  'checklist-pack route must occur exactly once in navigation');
+expect((navigation.match(/path: \/appendices\/figure-index\//g) || []).length === 1,
+  'figure-index route must occur exactly once in navigation');
+
+const publicFigureIndex = read('docs/appendices/figure-index/index.md');
+const sourceFigureIndex = read('src/appendices/figure-index/index.md');
+expect(stripFrontMatter(publicFigureIndex) === stripFrontMatter(sourceFigureIndex),
+  'source and public figure indexes must have matching bodies');
+const expectedIndexEntries = figures.map(([chapter, id, title], index) =>
+  `${index + 1}. [${title}](../../chapters/${chapter}/#${id})`);
+const actualIndexEntries = publicFigureIndex.match(/^\d+\. \[[^\]]+\]\([^)]+\).*$/gm) || [];
+expect(JSON.stringify(actualIndexEntries.map((line) => line.split(' — ')[0])) === JSON.stringify(expectedIndexEntries),
+  'figure index must contain the exact five entries in source order with contracted deep links');
+expect(!/(?:favicon|badge|logo|screenshot)/i.test(actualIndexEntries.join('\n')),
+  'figure index must not include UI assets or screenshot examples');
+
+const allPublicMarkdown = [];
+for (const [chapter, id] of figures) {
+  const publicFile = `docs/chapters/${chapter}/index.md`;
+  const sourceFile = `src/chapters/${chapter}/index.md`;
+  const publicContent = read(publicFile);
+  const sourceContent = read(sourceFile);
+  allPublicMarkdown.push(publicContent);
+  const pattern = new RegExp(`<figure id="${id}"[\\s\\S]*?<\\/figure>`);
+  const publicMatch = publicContent.match(pattern);
+  const sourceMatch = sourceContent.match(pattern);
+  expect(Boolean(publicMatch), `${publicFile}: missing stable figure ${id}`);
+  expect(Boolean(sourceMatch), `${sourceFile}: missing stable figure ${id}`);
+  expect(Boolean(publicMatch && sourceMatch) && normalize(publicMatch[0]) === normalize(sourceMatch[0]),
+    `${chapter}: source/public figure blocks must match`);
+  if (publicMatch) {
+    for (const value of ['<svg ', 'viewBox=', 'max-width: 100%', 'role="img"', '<title ', '<desc ', '<figcaption>']) {
+      expect(publicMatch[0].includes(value), `${publicFile}: ${id} lacks ${value}`);
+    }
+  }
+  expect(!publicContent.includes('```mermaid'), `${publicFile}: Mermaid must be removed`);
+  expect(!sourceContent.includes('```mermaid'), `${sourceFile}: Mermaid must be removed`);
+}
+const publicFigureIds = allPublicMarkdown.join('\n').match(/<figure id="figure-chapter[^\"]+"/g) || [];
+expect(publicFigureIds.length === 5, 'the five target chapters must publish exactly five contracted figures');
+
+const publicChecklist = read('docs/appendices/checklist-pack/index.md');
+const sourceChecklist = read('src/appendices/checklist-pack/index.md');
+expect(stripFrontMatter(publicChecklist) === stripFrontMatter(sourceChecklist),
+  'source and public checklist packs must have matching bodies');
+for (const section of ['準備', 'Issue と計画', 'ブランチとコミット', 'Pull Request とレビュー', 'CI/CD', 'セキュリティ', '組織・大規模運用']) {
+  expect(publicChecklist.includes(`## ${section}`), `checklist pack is missing section: ${section}`);
+}
+const checklistItems = publicChecklist.match(/^- \[ \] .+$/gm) || [];
+expect(checklistItems.length >= 21, 'checklist pack must contain at least 21 actionable checks');
+expect(checklistItems.every((item) => item.includes('根拠:') && /\.\.\/\.\.\/chapters\/chapter\d{2}\//.test(item)),
+  'every checklist item must link to at least one grounding chapter');
+expect(publicChecklist.includes('実施済み項目ではありません'),
+  'checklist pack must distinguish repository examples from completed checks');
+
+const css = read('docs/assets/css/main.css');
+expect(css.includes('.book-figure:not(.book-figure--narrow)') && css.includes('min-width: 720px'),
+  'mobile figure CSS must preserve text readability with a horizontal scroll viewport');
+const workflow = read('.github/workflows/book-qa.yml');
+expect(workflow.includes('node scripts/check-issue-240-ux.js'),
+  'Book QA must execute the Issue #240 UX contract');
+
+if (errors.length) {
+  console.error('Issue #240 UX contract failed:');
+  errors.forEach((error) => console.error(`- ${error}`));
+  process.exit(1);
+}
+console.log('Issue #240 UX contract passed.');

--- a/scripts/check-metadata-consistency.js
+++ b/scripts/check-metadata-consistency.js
@@ -24,7 +24,11 @@ const EXPECTED = {
 const EXPECTED_NAV = {
   introduction: ['/introduction/'],
   chapters: Array.from({ length: 17 }, (_, i) => `/chapters/chapter${String(i + 1).padStart(2, '0')}/`),
-  appendices: ['a', 'b', 'c', 'd', 'e', 'f', 'g'].map((letter) => `/appendices/appendix-${letter}/`),
+  appendices: [
+    ...['a', 'b', 'c', 'd', 'e', 'f', 'g'].map((letter) => `/appendices/appendix-${letter}/`),
+    '/appendices/checklist-pack/',
+    '/appendices/figure-index/'
+  ],
   afterword: ['/afterword/']
 };
 

--- a/src/appendices/checklist-pack/index.md
+++ b/src/appendices/checklist-pack/index.md
@@ -1,0 +1,57 @@
+---
+layout: book
+title: "独立チェックリスト集"
+---
+
+# 独立チェックリスト集
+
+この付録は、章内に点在する確認事項を実運用の目的別に再編したものです。各項目は未実施の確認作業として扱います。章内のコードブロックや設定例は、実施済みを示すものではありません。
+
+## 準備
+
+- [ ] 対象リポジトリ、責任者、利用するGitHubアカウントまたは組織を確認した。根拠: [第1章](../../chapters/chapter01/)、[第5章](../../chapters/chapter05/)
+- [ ] Gitのユーザー設定、認証方法、必要な開発環境をプロジェクトのルールに合わせた。根拠: [第3章](../../chapters/chapter03/)
+- [ ] 機密情報、学習データ、ライセンスの扱いを公開前に確認した。根拠: [第5章](../../chapters/chapter05/)、[第17章](../../chapters/chapter17/)、[付録G](../appendix-g/)
+
+## Issue と計画
+
+- [ ] Issueに目的、受入基準、制約、変更禁止領域を記録した。根拠: [第2章](../../chapters/chapter02/)、[第4章](../../chapters/chapter04/)
+- [ ] 影響範囲、検証方法、ロールバック方針を作業開始前に合意した。根拠: [第2章](../../chapters/chapter02/)、[第11章](../../chapters/chapter11/)
+- [ ] AI支援を使う場合は、入力可能な情報と人間の確認責任を明確にした。根拠: [第2章](../../chapters/chapter02/)、[第6章](../../chapters/chapter06/)
+
+## ブランチとコミット
+
+- [ ] 変更目的に対応する短命ブランチを作成し、mainへの直接変更を避けた。根拠: [第1章](../../chapters/chapter01/)、[第12章](../../chapters/chapter12/)
+- [ ] コミットをレビュー可能な単位に分け、意図と検証結果を説明できる状態にした。根拠: [第1章](../../chapters/chapter01/)、[第3章](../../chapters/chapter03/)
+- [ ] 実験、release、不要になったブランチの扱いをチームで定義した。根拠: [第12章](../../chapters/chapter12/)
+
+## Pull Request とレビュー
+
+- [ ] PRに変更内容、影響範囲、検証、ロールバック、AI利用の有無を記載した。根拠: [第2章](../../chapters/chapter02/)、[第7章](../../chapters/chapter07/)
+- [ ] 人間が仕様、リスク、セキュリティ上の判断を確認し、AIレビューだけで承認しない。根拠: [第7章](../../chapters/chapter07/)
+- [ ] CODEOWNERS、必須レビュアー、承認条件が対象変更に適用されることを確認した。根拠: [第9章](../../chapters/chapter09/)
+
+## CI/CD
+
+- [ ] 必須テスト、静的解析、依存関係確認をPRの品質ゲートとして実行した。根拠: [第7章](../../chapters/chapter07/)、[第13章](../../chapters/chapter13/)
+- [ ] デプロイ対象環境、承認者、Secretsの参照範囲を確認した。根拠: [第11章](../../chapters/chapter11/)、[第13章](../../chapters/chapter13/)
+- [ ] 失敗時の停止、再実行、ロールバックの手順を検証可能な形で残した。根拠: [第11章](../../chapters/chapter11/)、[付録B](../appendix-b/)
+
+## セキュリティ
+
+- [ ] トークン、パスワード、個人情報、機密データをコード、ログ、Issue、PRへ含めていない。根拠: [第8章](../../chapters/chapter08/)、[第11章](../../chapters/chapter11/)
+- [ ] 入力検証、認証・認可、依存関係更新、破壊的変更のリスクを確認した。根拠: [第7章](../../chapters/chapter07/)、[第8章](../../chapters/chapter08/)
+- [ ] Secret scanning、code scanning、dependency reviewの結果を確認し、例外があれば記録した。根拠: [第8章](../../chapters/chapter08/)
+
+## 組織・大規模運用
+
+- [ ] 組織、チーム、リポジトリの権限継承と直接付与を監査した。根拠: [第9章](../../chapters/chapter09/)、[第10章](../../chapters/chapter10/)
+- [ ] Outside Collaborator、SAML SSO、監査ログの運用を組織ポリシーと照合した。根拠: [第10章](../../chapters/chapter10/)
+- [ ] 大規模データ、モデル、外部協力者、コンプライアンスの責任分界を確認した。根拠: [第14章](../../chapters/chapter14/)、[第16章](../../chapters/chapter16/)、[第17章](../../chapters/chapter17/)
+
+## 関連資料
+
+次の資料はリポジトリ内の導入例であり、この公開チェックリストの実施済み項目ではありません。対象リポジトリの公開範囲と運用文脈を確認したうえで参照してください。
+
+- <https://github.com/itdojp/github-workflow-book/blob/main/examples/ai-agent-starter/security-checklist.md> — AIエージェント向けSecurity checklist: AIレビューの見落としを前提に人間が確認する最小例。
+- <https://github.com/itdojp/github-workflow-book/blob/main/examples/self-hosted-runner-ops-checklist/README.md> — self-hosted runner運用チェックリスト: trusted input、runner分離、ephemeral運用を扱う導入例。

--- a/src/appendices/figure-index/index.md
+++ b/src/appendices/figure-index/index.md
@@ -1,0 +1,16 @@
+---
+layout: book
+title: "図表索引"
+---
+
+# 図表索引
+
+この索引は、本書の公開本文に掲載する自己完結SVG図版のexact inventoryです。スクリーンショット用コード例、badge、favicon、logoは含めません。
+
+1. [図1.1：ローカルとリモートの同期](../../chapters/chapter01/#figure-chapter01-repository-sync) — 作業ディレクトリ、ステージング、ローカルリポジトリ、GitHubの同期。
+2. [図5.1：Public / Privateリポジトリの判断フロー](../../chapters/chapter05/#figure-chapter05-repository-visibility) — 公開制約と公開目的に基づく可視性の選択。
+3. [図7.1：ハイブリッドレビューワークフロー](../../chapters/chapter07/#figure-chapter07-hybrid-review-flow) — AIレビュー、人間レビュー、CIの品質ゲート。
+4. [図9.1：組織からリポジトリへの権限継承](../../chapters/chapter09/#figure-chapter09-permission-inheritance) — Organization、Team、Repositoryの権限経路。
+5. [図12.1：ML開発向けGit Flow](../../chapters/chapter12/#figure-chapter12-ml-git-flow) — feature、experiment、releaseを含む統合フロー。
+
+各リンクは該当する`figure`要素のstable anchorへ直接移動します。図版はJavaScriptを必要とせず、SVG内のtitleと説明、captionを備えます。

--- a/src/chapters/chapter01/index.md
+++ b/src/chapters/chapter01/index.md
@@ -144,17 +144,24 @@ main
 
 ### 同期の仕組み
 
-```mermaid
-graph LR
-    A[作業ディレクトリ] -->|add| B[ステージングエリア]
-    B -->|commit| C[ローカルリポジトリ]
-    C <-->|push/pull| D[リモートリポジトリ<br/>GitHub]
-    
-    style A fill:#f9f9f9,stroke:#333,stroke-width:2px
-    style B fill:#e1f5e1,stroke:#333,stroke-width:2px
-    style C fill:#e1e5f5,stroke:#333,stroke-width:2px
-    style D fill:#ffe1e1,stroke:#333,stroke-width:2px
-```
+<!-- markdownlint-disable MD033 -->
+<figure id="figure-chapter01-repository-sync" class="book-figure">
+  <svg style="display: block; max-width: 100%; height: auto; margin: 0 auto;" viewBox="0 0 960 260" width="960" height="260" role="img" aria-labelledby="figure-chapter01-repository-sync-title figure-chapter01-repository-sync-desc" xmlns="http://www.w3.org/2000/svg">
+    <title id="figure-chapter01-repository-sync-title">ローカルとリモートの同期</title>
+    <desc id="figure-chapter01-repository-sync-desc">作業ディレクトリからステージングエリア、ローカルリポジトリへ進み、ローカルリポジトリとGitHub上のリモートリポジトリをpushとpullで双方向に同期する流れ。</desc>
+    <defs><marker id="sync-arrow" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto"><path d="M0,0 L10,4 L0,8 Z" fill="#1f2937"/></marker></defs>
+    <style>.sync-box{stroke:#1f2937;stroke-width:3}.sync-text{fill:#111827;font:600 18px sans-serif}.sync-label{fill:#111827;font:16px sans-serif}.sync-line{stroke:#1f2937;stroke-width:3;marker-end:url(#sync-arrow)}</style>
+    <rect class="sync-box" x="25" y="80" width="180" height="80" rx="10" fill="#f9fafb"/><text class="sync-text" x="115" y="112" text-anchor="middle">作業</text><text class="sync-text" x="115" y="137" text-anchor="middle">ディレクトリ</text>
+    <rect class="sync-box" x="270" y="80" width="180" height="80" rx="10" fill="#dcfce7"/><text class="sync-text" x="360" y="123" text-anchor="middle">ステージングエリア</text>
+    <rect class="sync-box" x="515" y="80" width="180" height="80" rx="10" fill="#dbeafe"/><text class="sync-text" x="605" y="112" text-anchor="middle">ローカル</text><text class="sync-text" x="605" y="137" text-anchor="middle">リポジトリ</text>
+    <rect class="sync-box" x="760" y="70" width="175" height="100" rx="10" fill="#fee2e2"/><text class="sync-text" x="847" y="101" text-anchor="middle">リモート</text><text class="sync-text" x="847" y="126" text-anchor="middle">リポジトリ</text><text class="sync-label" x="847" y="150" text-anchor="middle">（GitHub）</text>
+    <line class="sync-line" x1="205" y1="120" x2="260" y2="120"/><text class="sync-label" x="232" y="68" text-anchor="middle">add</text>
+    <line class="sync-line" x1="450" y1="120" x2="505" y2="120"/><text class="sync-label" x="477" y="68" text-anchor="middle">commit</text>
+    <line class="sync-line" x1="695" y1="105" x2="750" y2="105"/><line class="sync-line" x1="760" y1="140" x2="705" y2="140"/><text class="sync-label" x="727" y="68" text-anchor="middle">push</text><text class="sync-label" x="727" y="190" text-anchor="middle">pull</text>
+  </svg>
+  <figcaption>図1.1：ローカル作業からGitHub上のリモートリポジトリまでの同期。矢印のラベルは実行するGit操作を示す。</figcaption>
+</figure>
+<!-- markdownlint-enable MD033 -->
 
 ### リモートブランチの追跡
 - ローカルブランチとリモートブランチの対応

--- a/src/chapters/chapter05/index.md
+++ b/src/chapters/chapter05/index.md
@@ -147,30 +147,36 @@ policies:
 
 ### AI協働を含む判断フローチャート
 
-```mermaid
-flowchart TD
-    A[リポジトリ作成] --> B{機密情報を含むか？}
-    B -->|Yes| C[Private]
-    B -->|No| D{AI生成コードの<br/>知的財産権が懸念されるか？}
-    D -->|Yes| E[Private + AI使用ポリシー明記]
-    D -->|No| F{特許や独自アルゴリズムを含むか？}
-    F -->|Yes| G[Private]
-    F -->|No| H{オープンソースとして<br/>公開する意図があるか？}
-    H -->|Yes| I[Public + AI協働の明示]
-    H -->|No| J{AI協働の学習事例として<br/>共有したいか？}
-    J -->|Yes| K[Public + AI協働ドキュメント]
-    J -->|No| L{教育目的や<br/>ポートフォリオか？}
-    L -->|Yes| M[Public]
-    L -->|No| N[Private]
-    
-    style C fill:#ffcccc
-    style E fill:#ffcccc
-    style G fill:#ffcccc
-    style N fill:#ffcccc
-    style I fill:#ccffcc
-    style K fill:#ccffcc
-    style M fill:#ccffcc
-```
+<!-- markdownlint-disable MD033 -->
+<figure id="figure-chapter05-repository-visibility" class="book-figure">
+  <svg style="display: block; max-width: 100%; height: auto; margin: 0 auto;" viewBox="0 0 760 900" width="760" height="900" role="img" aria-labelledby="figure-chapter05-repository-visibility-title figure-chapter05-repository-visibility-desc" xmlns="http://www.w3.org/2000/svg">
+    <title id="figure-chapter05-repository-visibility-title">PublicとPrivateリポジトリの判断</title>
+    <desc id="figure-chapter05-repository-visibility-desc">機密情報、AI生成コードの知的財産権、特許・独自アルゴリズム、オープンソース公開の意図、AI協働の学習事例共有、教育・ポートフォリオの順に確認する。各質問のはい側でPrivateまたは目的別のPublicを選び、すべていいえの場合はPrivateを選ぶ判断フロー。</desc>
+    <defs><marker id="visibility-arrow" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto"><path d="M0,0 L10,4 L0,8 Z" fill="#1f2937"/></marker></defs>
+    <style>.visibility-node{stroke:#1f2937;stroke-width:3}.visibility-text{fill:#111827;font:600 17px sans-serif}.visibility-small{fill:#111827;font:15px sans-serif}.visibility-line{fill:none;stroke:#1f2937;stroke-width:3;marker-end:url(#visibility-arrow)}.visibility-answer{fill:#111827;font:600 15px sans-serif}</style>
+    <rect class="visibility-node" x="270" y="15" width="220" height="54" rx="10" fill="#e0f2fe"/><text class="visibility-text" x="380" y="49" text-anchor="middle">リポジトリ作成</text>
+    <polygon class="visibility-node" points="380,88 570,133 380,178 190,133" fill="#fef3c7"/><text class="visibility-text" x="380" y="139" text-anchor="middle">機密情報を含むか？</text>
+    <rect class="visibility-node" x="20" y="105" width="140" height="56" rx="10" fill="#fee2e2"/><text class="visibility-text" x="90" y="140" text-anchor="middle">Private</text><path class="visibility-line" d="M190 133 H170"/><text class="visibility-answer" x="170" y="98" text-anchor="middle">はい</text>
+    <path class="visibility-line" d="M380 178 V203"/><text class="visibility-answer" x="397" y="197">いいえ</text>
+    <polygon class="visibility-node" points="380,210 590,262 380,314 170,262" fill="#fef3c7"/><text class="visibility-text" x="380" y="254" text-anchor="middle">AI生成コードの知的財産権が</text><text class="visibility-text" x="380" y="278" text-anchor="middle">懸念されるか？</text>
+    <rect class="visibility-node" x="5" y="230" width="150" height="64" rx="10" fill="#fee2e2"/><text class="visibility-small" x="80" y="256" text-anchor="middle">Private＋</text><text class="visibility-small" x="80" y="278" text-anchor="middle">AI使用ポリシー</text><path class="visibility-line" d="M170 262 H165"/><text class="visibility-answer" x="165" y="222" text-anchor="middle">はい</text>
+    <path class="visibility-line" d="M380 314 V339"/><text class="visibility-answer" x="397" y="333">いいえ</text>
+    <polygon class="visibility-node" points="380,346 580,394 380,442 180,394" fill="#fef3c7"/><text class="visibility-text" x="380" y="387" text-anchor="middle">特許や独自アルゴリズムを</text><text class="visibility-text" x="380" y="411" text-anchor="middle">含むか？</text>
+    <rect class="visibility-node" x="20" y="366" width="140" height="56" rx="10" fill="#fee2e2"/><text class="visibility-text" x="90" y="401" text-anchor="middle">Private</text><path class="visibility-line" d="M180 394 H170"/><text class="visibility-answer" x="170" y="354" text-anchor="middle">はい</text>
+    <path class="visibility-line" d="M380 442 V467"/><text class="visibility-answer" x="397" y="461">いいえ</text>
+    <polygon class="visibility-node" points="380,474 580,522 380,570 180,522" fill="#fef3c7"/><text class="visibility-text" x="380" y="515" text-anchor="middle">オープンソースとして</text><text class="visibility-text" x="380" y="539" text-anchor="middle">公開する意図があるか？</text>
+    <rect class="visibility-node" x="600" y="490" width="150" height="64" rx="10" fill="#dcfce7"/><text class="visibility-small" x="675" y="516" text-anchor="middle">Public＋</text><text class="visibility-small" x="675" y="538" text-anchor="middle">AI協働の明示</text><path class="visibility-line" d="M580 522 H590"/><text class="visibility-answer" x="590" y="480" text-anchor="middle">はい</text>
+    <path class="visibility-line" d="M380 570 V595"/><text class="visibility-answer" x="397" y="589">いいえ</text>
+    <polygon class="visibility-node" points="380,602 580,650 380,698 180,650" fill="#fef3c7"/><text class="visibility-text" x="380" y="643" text-anchor="middle">AI協働の学習事例として</text><text class="visibility-text" x="380" y="667" text-anchor="middle">共有したいか？</text>
+    <rect class="visibility-node" x="600" y="618" width="150" height="64" rx="10" fill="#dcfce7"/><text class="visibility-small" x="675" y="644" text-anchor="middle">Public＋</text><text class="visibility-small" x="675" y="666" text-anchor="middle">AI協働文書</text><path class="visibility-line" d="M580 650 H590"/><text class="visibility-answer" x="590" y="608" text-anchor="middle">はい</text>
+    <path class="visibility-line" d="M380 698 V723"/><text class="visibility-answer" x="397" y="717">いいえ</text>
+    <polygon class="visibility-node" points="380,730 570,775 380,820 190,775" fill="#fef3c7"/><text class="visibility-text" x="380" y="768" text-anchor="middle">教育目的または</text><text class="visibility-text" x="380" y="792" text-anchor="middle">ポートフォリオか？</text>
+    <rect class="visibility-node" x="600" y="747" width="140" height="56" rx="10" fill="#dcfce7"/><text class="visibility-text" x="670" y="782" text-anchor="middle">Public</text><path class="visibility-line" d="M570 775 H590"/><text class="visibility-answer" x="590" y="736" text-anchor="middle">はい</text>
+    <path class="visibility-line" d="M380 820 V844"/><text class="visibility-answer" x="397" y="839">いいえ</text><rect class="visibility-node" x="310" y="844" width="140" height="50" rx="10" fill="#fee2e2"/><text class="visibility-text" x="380" y="876" text-anchor="middle">Private</text>
+  </svg>
+  <figcaption>図5.1：Public / Private リポジトリの判断フロー。機密性、知的財産、公開意図、共有・教育目的を順に確認し、公開時はAI協働の方針を明示する。</figcaption>
+</figure>
+<!-- markdownlint-enable MD033 -->
 
 ### Publicリポジトリの利点
 - **コミュニティ貢献**: オープンソースエコシステムへの参加

--- a/src/chapters/chapter07/index.md
+++ b/src/chapters/chapter07/index.md
@@ -233,16 +233,25 @@ def calculate_metrics(y_true, y_pred, threshold=0.5):
 
 ### ハイブリッドレビューワークフロー
 
-```mermaid
-graph LR
-    A[PR作成] --> B[AI自動レビュー]
-    B --> C{重大な問題?}
-    C -->|Yes| D[自動ブロック]
-    C -->|No| E[人間レビュー待ち]
-    E --> F[人間がAIコメント確認]
-    F --> G[追加レビュー]
-    G --> H[承認/要修正]
-```
+<!-- markdownlint-disable MD033 -->
+<figure id="figure-chapter07-hybrid-review-flow" class="book-figure">
+  <svg style="display: block; max-width: 100%; height: auto; margin: 0 auto;" viewBox="0 0 1080 300" width="1080" height="300" role="img" aria-labelledby="figure-chapter07-hybrid-review-flow-title figure-chapter07-hybrid-review-flow-desc" xmlns="http://www.w3.org/2000/svg">
+    <title id="figure-chapter07-hybrid-review-flow-title">ハイブリッドレビューワークフロー</title>
+    <desc id="figure-chapter07-hybrid-review-flow-desc">PR作成後、任意のAIレビュー、人間による仕様とリスクのレビュー、CIを順番に実施する。要修正なら修正と再レビューへ戻り、不要なら承認してマージする。</desc>
+    <defs><marker id="review-arrow" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto"><path d="M0,0 L10,4 L0,8 Z" fill="#1f2937"/></marker></defs>
+    <style>.review-box{stroke:#1f2937;stroke-width:3}.review-text{fill:#111827;font:600 16px sans-serif}.review-label{fill:#111827;font:15px sans-serif}.review-line{fill:none;stroke:#1f2937;stroke-width:3;marker-end:url(#review-arrow)}</style>
+    <rect class="review-box" x="20" y="105" width="145" height="60" rx="10" fill="#e0f2fe"/><text class="review-text" x="92" y="141" text-anchor="middle">PR作成</text>
+    <rect class="review-box" x="205" y="90" width="185" height="90" rx="10" fill="#ede9fe"/><text class="review-text" x="297" y="125" text-anchor="middle">任意：AIレビュー</text><text class="review-label" x="297" y="151" text-anchor="middle">Copilot code review</text>
+    <rect class="review-box" x="430" y="90" width="195" height="90" rx="10" fill="#fef3c7"/><text class="review-text" x="527" y="125" text-anchor="middle">人間レビュー</text><text class="review-label" x="527" y="151" text-anchor="middle">仕様・リスク判断</text>
+    <rect class="review-box" x="665" y="90" width="145" height="90" rx="10" fill="#dbeafe"/><text class="review-text" x="737" y="125" text-anchor="middle">CI</text><text class="review-label" x="737" y="151" text-anchor="middle">テスト・静的解析</text>
+    <polygon class="review-box" points="900,90 980,135 900,180 820,135" fill="#fef3c7"/><text class="review-text" x="900" y="141" text-anchor="middle">要修正？</text>
+    <rect class="review-box" x="855" y="225" width="180" height="55" rx="10" fill="#fee2e2"/><text class="review-text" x="945" y="259" text-anchor="middle">修正・再レビュー</text>
+    <rect class="review-box" x="850" y="20" width="185" height="50" rx="10" fill="#dcfce7"/><text class="review-text" x="942" y="52" text-anchor="middle">承認・マージ</text>
+    <path class="review-line" d="M165 135 H195"/><path class="review-line" d="M390 135 H420"/><path class="review-line" d="M625 135 H655"/><path class="review-line" d="M810 135 H820"/><path class="review-line" d="M900 90 V70"/><text class="review-label" x="918" y="86">いいえ</text><path class="review-line" d="M900 180 V225"/><text class="review-label" x="918" y="205">はい</text><path class="review-line" d="M855 252 H527 V180"/>
+  </svg>
+  <figcaption>図7.1：AIレビューを補助として使い、人間の仕様・リスク判断とCIを必須の品質ゲートとして組み合わせるハイブリッドレビュー。</figcaption>
+</figure>
+<!-- markdownlint-enable MD033 -->
 
 ### レビュー優先順位の設定
 

--- a/src/chapters/chapter09/index.md
+++ b/src/chapters/chapter09/index.md
@@ -586,18 +586,24 @@ class ReviewBot:
 ### 組織からリポジトリへの権限継承
 
 #### 継承の仕組み
-```mermaid
-graph TD
-    A[Organization Owner] --> B[Organization Member]
-    B --> C[Team Member]
-    C --> D[Repository Access]
-    
-    A --> E[Direct Repository Admin]
-    E --> D
-    
-    C --> F[Team Repository Permission]
-    F --> D
-```
+<!-- markdownlint-disable MD033 -->
+<figure id="figure-chapter09-permission-inheritance" class="book-figure">
+  <svg style="display: block; max-width: 100%; height: auto; margin: 0 auto;" viewBox="0 0 920 420" width="920" height="420" role="img" aria-labelledby="figure-chapter09-permission-inheritance-title figure-chapter09-permission-inheritance-desc" xmlns="http://www.w3.org/2000/svg">
+    <title id="figure-chapter09-permission-inheritance-title">組織からリポジトリへの権限継承</title>
+    <desc id="figure-chapter09-permission-inheritance-desc">Organization OwnerからOrganization Member、Team Member、Repository Accessへ継承する経路と、直接のRepository AdminおよびTeam Repository PermissionからRepository Accessへ到達する経路。</desc>
+    <defs><marker id="permission-arrow" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto"><path d="M0,0 L10,4 L0,8 Z" fill="#1f2937"/></marker></defs>
+    <style>.permission-box{stroke:#1f2937;stroke-width:3}.permission-text{fill:#111827;font:600 17px sans-serif}.permission-line{fill:none;stroke:#1f2937;stroke-width:3;marker-end:url(#permission-arrow)}</style>
+    <rect class="permission-box" x="350" y="20" width="220" height="60" rx="10" fill="#e0f2fe"/><text class="permission-text" x="460" y="57" text-anchor="middle">Organization Owner</text>
+    <rect class="permission-box" x="350" y="125" width="220" height="60" rx="10" fill="#dbeafe"/><text class="permission-text" x="460" y="162" text-anchor="middle">Organization Member</text>
+    <rect class="permission-box" x="350" y="230" width="220" height="60" rx="10" fill="#ede9fe"/><text class="permission-text" x="460" y="267" text-anchor="middle">Team Member</text>
+    <rect class="permission-box" x="40" y="230" width="230" height="60" rx="10" fill="#fef3c7"/><text class="permission-text" x="155" y="267" text-anchor="middle">Direct Repository Admin</text>
+    <rect class="permission-box" x="650" y="225" width="230" height="75" rx="10" fill="#fef3c7"/><text class="permission-text" x="765" y="257" text-anchor="middle">Team Repository</text><text class="permission-text" x="765" y="281" text-anchor="middle">Permission</text>
+    <rect class="permission-box" x="335" y="345" width="250" height="60" rx="10" fill="#dcfce7"/><text class="permission-text" x="460" y="382" text-anchor="middle">Repository Access</text>
+    <path class="permission-line" d="M460 80 V115"/><path class="permission-line" d="M460 185 V220"/><path class="permission-line" d="M460 290 V335"/><path class="permission-line" d="M395 80 C260 110,155 150,155 220"/><path class="permission-line" d="M570 260 H650"/><path class="permission-line" d="M155 290 C155 325,300 355,325 365"/><path class="permission-line" d="M765 300 C765 325,620 355,595 365"/>
+  </svg>
+  <figcaption>図9.1：組織、チーム、直接付与の経路からリポジトリ権限へ至る関係。実効権限は組織ポリシーとリポジトリ設定も併せて確認する。</figcaption>
+</figure>
+<!-- markdownlint-enable MD033 -->
 
 ### 権限の優先順位
 

--- a/src/chapters/chapter12/index.md
+++ b/src/chapters/chapter12/index.md
@@ -107,43 +107,24 @@ image-classification/
 ### ブランチ戦略
 
 #### ML開発向けGit Flow
-```mermaid
-gitGraph
-    commit id: "Initial"
-    branch develop
-    checkout develop
-    commit id: "Setup"
-    
-    branch feature/data-pipeline
-    checkout feature/data-pipeline
-    commit id: "Add loader"
-    commit id: "Add augmentation"
-    checkout develop
-    merge feature/data-pipeline
-    
-    branch experiment/resnet50
-    checkout experiment/resnet50
-    commit id: "ResNet50 base"
-    commit id: "Tune hyperparams"
-    
-    branch experiment/efficientnet
-    checkout experiment/efficientnet
-    commit id: "EfficientNet base"
-    commit id: "Optimize"
-    
-    checkout develop
-    merge experiment/resnet50
-    
-    branch release/v1.0
-    checkout release/v1.0
-    commit id: "Prepare release"
-    
-    checkout main
-    merge release/v1.0 tag: "v1.0"
-    
-    checkout develop
-    merge release/v1.0
-```
+<!-- markdownlint-disable MD033 -->
+<figure id="figure-chapter12-ml-git-flow" class="book-figure book-figure--narrow">
+  <svg style="display: block; max-width: 100%; height: auto; margin: 0 auto;" viewBox="0 0 360 650" width="360" height="650" role="img" aria-labelledby="figure-chapter12-ml-git-flow-title figure-chapter12-ml-git-flow-desc" xmlns="http://www.w3.org/2000/svg">
+    <title id="figure-chapter12-ml-git-flow-title">ML開発向けGit Flow</title>
+    <desc id="figure-chapter12-ml-git-flow-desc">mainからdevelopを作成する。data pipelineのfeatureブランチ、ResNet50とEfficientNetのexperimentブランチをdevelopから分岐する。採用した実験をdevelopへ統合し、release v1.0をmainへマージしてタグ付けし、developへ戻す流れ。</desc>
+    <defs><marker id="gitflow-arrow" markerWidth="8" markerHeight="7" refX="7" refY="3.5" orient="auto"><path d="M0,0 L8,3.5 L0,7 Z" fill="#1f2937"/></marker></defs>
+    <style>.gitflow-line{stroke-width:4;fill:none}.gitflow-main{stroke:#1d4ed8}.gitflow-dev{stroke:#047857}.gitflow-feature{stroke:#7c3aed}.gitflow-experiment{stroke:#c2410c}.gitflow-release{stroke:#be123c}.gitflow-dot{stroke:#111827;stroke-width:1.5}.gitflow-text{fill:#111827;font:600 14px sans-serif}.gitflow-note{fill:#111827;font:12px sans-serif}.gitflow-merge{fill:none;stroke:#1f2937;stroke-width:2.5;marker-end:url(#gitflow-arrow)}</style>
+    <text class="gitflow-text" x="12" y="65">main</text><path class="gitflow-line gitflow-main" d="M125 60 H335"/><circle class="gitflow-dot" cx="145" cy="60" r="6" fill="#1d4ed8"/><circle class="gitflow-dot" cx="315" cy="60" r="6" fill="#1d4ed8"/><text class="gitflow-note" x="132" y="43">Initial</text><text class="gitflow-note" x="300" y="43">v1.0</text>
+    <text class="gitflow-text" x="12" y="145">develop</text><path class="gitflow-line gitflow-dev" d="M125 140 H335"/><circle class="gitflow-dot" cx="145" cy="140" r="6" fill="#047857"/><circle class="gitflow-dot" cx="245" cy="140" r="6" fill="#047857"/><circle class="gitflow-dot" cx="315" cy="140" r="6" fill="#047857"/><text class="gitflow-note" x="132" y="123">Setup</text>
+    <text class="gitflow-text" x="12" y="225">feature/</text><text class="gitflow-text" x="12" y="243">data-pipeline</text><path class="gitflow-line gitflow-feature" d="M125 230 H235"/><circle class="gitflow-dot" cx="160" cy="230" r="6" fill="#7c3aed"/><circle class="gitflow-dot" cx="215" cy="230" r="6" fill="#7c3aed"/><text class="gitflow-note" x="142" y="258">loader・augmentation</text>
+    <text class="gitflow-text" x="12" y="325">experiment/</text><text class="gitflow-text" x="12" y="343">resnet50</text><path class="gitflow-line gitflow-experiment" d="M125 330 H235"/><circle class="gitflow-dot" cx="160" cy="330" r="6" fill="#c2410c"/><circle class="gitflow-dot" cx="215" cy="330" r="6" fill="#c2410c"/><text class="gitflow-note" x="138" y="358">base・tuning</text>
+    <text class="gitflow-text" x="12" y="425">experiment/</text><text class="gitflow-text" x="12" y="443">efficientnet</text><path class="gitflow-line gitflow-experiment" d="M125 430 H235"/><circle class="gitflow-dot" cx="160" cy="430" r="6" fill="#c2410c"/><circle class="gitflow-dot" cx="215" cy="430" r="6" fill="#c2410c"/><text class="gitflow-note" x="138" y="458">base・optimize</text>
+    <text class="gitflow-text" x="12" y="525">release/</text><text class="gitflow-text" x="12" y="543">v1.0</text><path class="gitflow-line gitflow-release" d="M125 530 H235"/><circle class="gitflow-dot" cx="180" cy="530" r="6" fill="#be123c"/><text class="gitflow-note" x="142" y="558">Prepare release</text>
+    <path class="gitflow-merge" d="M145 140 V220 H125"/><path class="gitflow-merge" d="M145 140 V320 H125"/><path class="gitflow-merge" d="M145 140 V420 H125"/><path class="gitflow-merge" d="M235 230 V140 H245"/><path class="gitflow-merge" d="M235 330 V140 H245"/><path class="gitflow-merge" d="M245 140 V520 H125"/><path class="gitflow-merge" d="M235 530 V60 H315"/><path class="gitflow-merge" d="M235 530 V140 H315"/>
+  </svg>
+  <figcaption>図12.1：ML開発向けGit Flow。実験ブランチをdevelopから分岐し、採用した実験だけを統合してrelease経由でmainへリリースする。</figcaption>
+</figure>
+<!-- markdownlint-enable MD033 -->
 
 ### 実装例
 

--- a/templates/styles/main.css
+++ b/templates/styles/main.css
@@ -353,6 +353,23 @@ img {
   box-shadow: var(--shadow-md);
 }
 
+.book-figure {
+  margin: 1.5rem 0;
+}
+
+@media (max-width: 640px) {
+  .book-figure:not(.book-figure--narrow) {
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+    padding-bottom: 0.5rem;
+  }
+
+  .book-figure:not(.book-figure--narrow) > svg {
+    min-width: 720px;
+    max-width: none !important;
+  }
+}
+
 /* Responsive Design */
 @media (max-width: 768px) {
   :root {


### PR DESCRIPTION
## 概要（必須）

- 変更内容: Profile B必須の独立チェックリスト集と図表索引を追加し、既存5 Mermaid図をJavaScript非依存・アクセシブルな自己完結SVGへ置換しました。公開正本 `docs/**` と安全な `src/**` ミラー、常設導線、UX flags、回帰契約を同期しています。

## 関連Issue/仕様（必須）

- Issue: Closes #240
- 仕様（要点）: `/appendices/checklist-pack/`、`/appendices/figure-index/`、exact 5 figures、付録G後/あとがき前の導線、`checklistPack=true` / `figureIndex=true`。

## 影響範囲（必須）

- 対象章/ページ: `/chapters/chapter01/`, `/chapters/chapter05/`, `/chapters/chapter07/`, `/chapters/chapter09/`, `/chapters/chapter12/`, 2付録、トップ、navigation。
- 影響: 既存Mermaid 5件のSVG化、独立モジュール追加、mobile横スクロール、QA契約追加。

## 受入基準（必須）

- [x] Issue の受入基準を満たす
- [x] 変更禁止領域に触れていない（または合意済み）
- [x] 章参照・内部リンク・アンカーが壊れていない

## テスト/検証（必須）

- 実行コマンドと結果:
  - `npm run test:light` — PASS（`npm audit` 0 vulnerabilities、metadata、Issue #240 contract、markdownlint、Jekyll build）
  - `node scripts/check-issue-240-ux.js` — PASS
  - `git diff --check` — PASS
  - SVG XML parse、docs/src figure block・付録本文 parity、5 deep links/anchors — PASS
- 手動確認: desktopおよび390px相当を実ブラウザで確認。通常4図は横スクロール、narrow図は縮小表示。第5章判断分岐、第7章review flow、第9章継承矢印を目視確認済み。
- 既知の既存債務: `python3 scripts/validate_links.py docs` は変更前から存在する外部/テンプレートURLを含む59件を報告します。今回追加した2 route・5 deep linkは専用契約で全件検証済みで、#235の依存関係warningとともに本PR非スコープです。

## リスク/ロールバック（必須）

- リスク: SVG内文字量が多いため、狭幅では縮小ではなく横スクロールを採用しています。
- ロールバック手順: 本PRのmerge commitをrevertし、MermaidとUX flags/navigationを従前へ戻します。

## Review 対応（必須）

- [ ] review 本文・inline comment・suggestion を全件確認した
- [ ] 修正した指摘には返信した
- [ ] 修正しない指摘には理由を返信した
- [ ] 未解決の review thread が 0 件である

## QA（必須）

- [ ] Book QA（Unicode / textlint(PRH) / 内部リンク・アンカー / Jekyll build / built-site smoke）: PASS
  - 実行URL: PR checksで追記
- [ ] 必須 status checks が green である

## merge 後確認（原則必須）

- [ ] main の checks が green である
- [ ] release / deploy / Pages など公開先の smoke test を実施した
- [ ] 完了証跡を関連 Issue に記録した

## Pages確認（原則必須）

- 確認URL: https://itdojp.github.io/github-workflow-book/
- [ ] トップページ HTTP 200
- [ ] 主要導線（navigation.yml 相当）で 404 が無い
- [ ] 表示崩れが無い（図表/表/コード中心）

## AI支援/エージェント利用の開示（任意）

- AI/エージェント利用: 有
- 利用範囲: 実装、契約checker、独立レビュー、視覚検証補助
- 人間が最終確認した観点: Issue契約、変更所有権、レビュー対応、CI/公開証跡

## 補足

- #235（npm allowScripts / Faraday warning）は混在させていません。
- `_site/`、`node_modules/`等の生成物はcommitしていません。
