### PR TITLE
docs: Dependency Reviewをmerge queue対応にする

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -50,6 +50,11 @@ jobs:
           node scripts/check-chapter08-codeql-contract.js
           node scripts/check-chapter08-codeql-contract.js --self-test
 
+      - name: Check Chapter 8 dependency review merge queue contract
+        run: |
+          node scripts/check-chapter08-dependency-review-contract.js
+          node scripts/check-chapter08-dependency-review-contract.js --self-test
+
       - name: Install dependencies (book-formatter)
         working-directory: book-formatter
         run: npm ci

--- a/docs/chapters/chapter08/index.md
+++ b/docs/chapters/chapter08/index.md
@@ -316,22 +316,27 @@ updates:
 
 ### Dependency reviewワークフロー
 
-#### PRでの依存関係チェック
+#### PRとmerge queueでの依存関係チェック
+
 ```yaml
 name: Dependency Review
 
-on: [pull_request]
+on:
+  pull_request:
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read
 
 jobs:
   dependency-review:
+    name: Dependency Review
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        
+
       - name: Dependency Review
         uses: actions/dependency-review-action@v4
         with:
@@ -339,6 +344,19 @@ jobs:
           deny-licenses: GPL-3.0, AGPL-3.0
           allow-ghsas: GHSA-xxxx-yyyy-zzzz
 ```
+
+merge queueは、queue内の変更を組み合わせたtemporary merge group commitに対して`checks_requested`を発行します。
+required checkにしたworkflowが`pull_request`だけを購読すると、このcommitに同じcheckが生成されずqueueが停止するため、`merge_group`でも同じ`Dependency Review` checkを実行します。
+required status checkの識別にはjob名が使われるため、`Dependency Review`というjob名を固定し、rulesetまたはbranch protectionではGitHubが返す正確なcheck名を選択してください。
+required checkにするworkflowへ`paths`または`paths-ignore` filterを設定すると、対象外のPRでworkflowがskipされ、checkがPendingのまま残るため設定しません。
+merge queueを使わないrepositoryでは`merge_group` eventが発火しないため、通常のPR検査を妨げません。
+全体のrequired check設計は[第13章のmerge queue節](../chapter13/)も参照してください。
+
+公式仕様:
+
+- Merge queue: <https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue>
+- `merge_group` event: <https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#merge_group>
+- Required status checksのtroubleshooting: <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks>
 
 ### ライセンスコンプライアンス
 

--- a/package.json
+++ b/package.json
@@ -19,13 +19,15 @@
     "deploy": "bash scripts/deploy.sh",
     "clean": "rm -rf _site public output temp",
     "lint:light": "markdownlint --config .markdownlint-src.json 'src/**/*.md' --ignore node_modules",
-    "test:light": "npm run check:security && npm run check:metadata && npm run check:chapter08-codeql && npm run check:chapter08-codeql:self-test && npm run check:issue-240-ux && npm run lint:light && npm run build",
+    "test:light": "npm run check:security && npm run check:metadata && npm run check:chapter08-codeql && npm run check:chapter08-codeql:self-test && npm run check:chapter08-dependency-review && npm run check:chapter08-dependency-review:self-test && npm run check:issue-240-ux && npm run lint:light && npm run build",
     "help": "echo 'Available commands:\n  npm run setup - Interactive setup\n  npm run build - Build the book\n  npm run preview - Local preview\n  npm run deploy - Deploy to GitHub Pages'",
     "build:generate": "node scripts/build-simple.js",
     "check:metadata": "node scripts/check-metadata-consistency.js",
     "check:security": "npm audit",
     "check:chapter08-codeql": "node scripts/check-chapter08-codeql-contract.js",
     "check:chapter08-codeql:self-test": "node scripts/check-chapter08-codeql-contract.js --self-test",
+    "check:chapter08-dependency-review": "node scripts/check-chapter08-dependency-review-contract.js",
+    "check:chapter08-dependency-review:self-test": "node scripts/check-chapter08-dependency-review-contract.js --self-test",
     "check:issue-240-ux": "node scripts/check-issue-240-ux.js"
   },
   "dependencies": {

--- a/scripts/check-chapter08-dependency-review-contract.js
+++ b/scripts/check-chapter08-dependency-review-contract.js
@@ -82,9 +82,16 @@ function validate(section) {
     errors.push('dependency-review jobがありません');
   } else {
     if (job.name !== 'Dependency Review') errors.push('required check用job名はDependency Reviewへ固定する必要があります');
-    const uses = Array.isArray(job.steps) ? job.steps.map((step) => step?.uses).filter(Boolean) : [];
+    if (Object.hasOwn(job, 'permissions')) errors.push('job-level permissionsで最小権限を上書きできません');
+    if (Object.hasOwn(job, 'if')) errors.push('merge_groupでjobをskipし得るjob-level ifは使用できません');
+    const steps = Array.isArray(job.steps) ? job.steps : [];
+    const uses = steps.map((step) => step?.uses).filter(Boolean);
     for (const action of ['actions/checkout@v4', 'actions/dependency-review-action@v4']) {
       if (!uses.includes(action)) errors.push(`${action}がありません`);
+    }
+    const dependencyReviewStep = steps.find((step) => step?.uses === 'actions/dependency-review-action@v4');
+    if (dependencyReviewStep && Object.hasOwn(dependencyReviewStep, 'if')) {
+      errors.push('merge_groupでDependency Review actionをskipし得るstep-level ifは使用できません');
     }
   }
 
@@ -149,6 +156,9 @@ if (process.argv.includes('--self-test')) {
   expectRejected(sourceSection, 'merge_group path filter', (value) => value.replace('    types: [checks_requested]', '    types: [checks_requested]\n    paths-ignore: ["docs/**"]'), 'path filter');
   expectRejected(sourceSection, 'job name drift', (value) => value.replace('    name: Dependency Review', '    name: Dependency Review Queue'), 'job名');
   expectRejected(sourceSection, 'broad permission', (value) => value.replace('contents: read', 'contents: write'), 'permissions');
+  expectRejected(sourceSection, 'job permission override', (value) => value.replace('    runs-on: ubuntu-latest', '    permissions:\n      contents: write\n    runs-on: ubuntu-latest'), 'job-level permissions');
+  expectRejected(sourceSection, 'job event condition', (value) => value.replace('    runs-on: ubuntu-latest', "    if: github.event_name == 'pull_request'\n    runs-on: ubuntu-latest"), 'job-level if');
+  expectRejected(sourceSection, 'dependency review event condition', (value) => value.replace('        uses: actions/dependency-review-action@v4', "        if: github.event_name == 'pull_request'\n        uses: actions/dependency-review-action@v4"), 'step-level if');
   expectRejected(sourceSection, 'missing action', (value) => value.replace('actions/dependency-review-action@v4', 'missing-dependency-review-action'), 'dependency-review-action@v4');
   console.log('Chapter 8 dependency review contract self-test passed.');
 } else {

--- a/scripts/check-chapter08-dependency-review-contract.js
+++ b/scripts/check-chapter08-dependency-review-contract.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const yamlParser = require('js-yaml');
+
+const sourcePath = 'src/chapters/chapter08/index.md';
+const publicPath = 'docs/chapters/chapter08/index.md';
+const sectionStart = '### Dependency reviewワークフロー';
+const sectionEnd = '### ライセンスコンプライアンス';
+
+function normalize(value) {
+  return value.replace(/\r\n?/g, '\n');
+}
+
+function readRequired(file) {
+  try {
+    return normalize(fs.readFileSync(file, 'utf8'));
+  } catch (error) {
+    console.error(`Chapter 8 dependency review contract failed: ${file}を読み込めません (${error.code ?? error.message})`);
+    process.exit(1);
+  }
+}
+
+function extractSection(content, file) {
+  const start = content.indexOf(sectionStart);
+  const end = content.indexOf(sectionEnd, start + sectionStart.length);
+  if (start === -1 || end === -1) throw new Error(`${file}: dependency review section is missing`);
+  return content.slice(start, end).trim();
+}
+
+function extractYaml(section) {
+  const match = section.match(/```yaml\n([\s\S]*?)\n```/);
+  return match?.[1] ?? '';
+}
+
+function validate(section) {
+  const errors = [];
+  const yaml = extractYaml(section);
+  if (!yaml) return ['dependency review YAML例がありません'];
+
+  let workflow;
+  try {
+    workflow = yamlParser.load(yaml);
+  } catch (error) {
+    return [`YAMLとしてparseできません: ${error.message.split('\n')[0]}`];
+  }
+  if (!workflow || typeof workflow !== 'object' || Array.isArray(workflow)) {
+    return ['YAMLのトップレベルはmappingである必要があります'];
+  }
+
+  const trigger = workflow.on;
+  if (!trigger || typeof trigger !== 'object' || !Object.hasOwn(trigger, 'pull_request')) {
+    errors.push('pull_request triggerがありません');
+  } else {
+    const pullRequest = trigger.pull_request;
+    if (pullRequest && typeof pullRequest === 'object'
+      && ['paths', 'paths-ignore'].some((key) => Object.hasOwn(pullRequest, key))) {
+      errors.push('required checkをskipさせるpull_requestのpath filterは使用できません');
+    }
+  }
+  if (!trigger || typeof trigger !== 'object' || !Object.hasOwn(trigger, 'merge_group')) {
+    errors.push('merge_group triggerがありません');
+  } else {
+    const types = trigger.merge_group?.types;
+    if (!Array.isArray(types) || types.length !== 1 || types[0] !== 'checks_requested') {
+      errors.push('merge_groupはchecks_requestedだけを購読する必要があります');
+    }
+    if (['paths', 'paths-ignore'].some((key) => Object.hasOwn(trigger.merge_group ?? {}, key))) {
+      errors.push('required checkをskipさせるmerge_groupのpath filterは使用できません');
+    }
+  }
+
+  const permissions = workflow.permissions;
+  if (!permissions || typeof permissions !== 'object'
+    || Object.keys(permissions).length !== 1 || permissions.contents !== 'read') {
+    errors.push('permissionsはcontents: readだけへ限定する必要があります');
+  }
+
+  const job = workflow.jobs?.['dependency-review'];
+  if (!job) {
+    errors.push('dependency-review jobがありません');
+  } else {
+    if (job.name !== 'Dependency Review') errors.push('required check用job名はDependency Reviewへ固定する必要があります');
+    const uses = Array.isArray(job.steps) ? job.steps.map((step) => step?.uses).filter(Boolean) : [];
+    for (const action of ['actions/checkout@v4', 'actions/dependency-review-action@v4']) {
+      if (!uses.includes(action)) errors.push(`${action}がありません`);
+    }
+  }
+
+  for (const marker of [
+    'temporary merge group commit',
+    '`checks_requested`',
+    '同じ`Dependency Review` check',
+    'required status checkの識別にはjob名が使われる',
+    '`paths`または`paths-ignore` filter',
+    'merge queueを使わないrepositoryでは`merge_group` eventが発火しない',
+    '[第13章のmerge queue節]',
+    'https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue',
+    'https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#merge_group',
+    'https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks',
+  ]) {
+    if (!section.includes(marker)) errors.push(`説明に必須markerがありません: ${marker}`);
+  }
+  return errors;
+}
+
+function expectRejected(section, name, mutate, expected) {
+  const mutated = mutate(section);
+  if (mutated === section) throw new Error(`self-test ${name}: mutation対象がありません`);
+  const errors = validate(mutated);
+  if (!errors.some((error) => error.includes(expected))) {
+    throw new Error(`self-test ${name}: 契約違反を拒否できません (${errors.join('; ')})`);
+  }
+}
+
+const sourceSection = extractSection(readRequired(sourcePath), sourcePath);
+const publicSection = extractSection(readRequired(publicPath), publicPath);
+const errors = [
+  ...validate(sourceSection).map((error) => `${sourcePath}: ${error}`),
+  ...validate(publicSection).map((error) => `${publicPath}: ${error}`),
+];
+if (sourceSection !== publicSection) errors.push('dependency review section must match between src and docs');
+
+const packageJson = JSON.parse(readRequired('package.json'));
+for (const command of ['npm run check:chapter08-dependency-review', 'npm run check:chapter08-dependency-review:self-test']) {
+  if (!packageJson.scripts?.['test:light']?.includes(command)) errors.push(`test:light must run ${command}`);
+}
+const workflow = readRequired('.github/workflows/book-qa.yml');
+for (const command of [
+  'node scripts/check-chapter08-dependency-review-contract.js',
+  'node scripts/check-chapter08-dependency-review-contract.js --self-test',
+]) {
+  if (!workflow.includes(command)) errors.push(`Book QA must run ${command}`);
+}
+
+if (errors.length) {
+  console.error('Chapter 8 dependency review contract failed:');
+  errors.forEach((error) => console.error(`- ${error}`));
+  process.exit(1);
+}
+
+if (process.argv.includes('--self-test')) {
+  expectRejected(sourceSection, 'malformed YAML', (value) => value.replace('jobs:', 'jobs'), 'parseできません');
+  expectRejected(sourceSection, 'missing pull_request', (value) => value.replace('  pull_request:\n', ''), 'pull_request');
+  expectRejected(sourceSection, 'missing merge_group', (value) => value.replace('  merge_group:\n    types: [checks_requested]\n', ''), 'merge_group');
+  expectRejected(sourceSection, 'wrong merge_group type', (value) => value.replace('types: [checks_requested]', 'types: [push]'), 'checks_requested');
+  expectRejected(sourceSection, 'pull_request path filter', (value) => value.replace('  pull_request:\n', '  pull_request:\n    paths: ["package-lock.json"]\n'), 'path filter');
+  expectRejected(sourceSection, 'merge_group path filter', (value) => value.replace('    types: [checks_requested]', '    types: [checks_requested]\n    paths-ignore: ["docs/**"]'), 'path filter');
+  expectRejected(sourceSection, 'job name drift', (value) => value.replace('    name: Dependency Review', '    name: Dependency Review Queue'), 'job名');
+  expectRejected(sourceSection, 'broad permission', (value) => value.replace('contents: read', 'contents: write'), 'permissions');
+  expectRejected(sourceSection, 'missing action', (value) => value.replace('actions/dependency-review-action@v4', 'missing-dependency-review-action'), 'dependency-review-action@v4');
+  console.log('Chapter 8 dependency review contract self-test passed.');
+} else {
+  console.log('Chapter 8 dependency review contract passed: pull_request/merge_group, stable job check name, no path filters, and minimum permissions.');
+}

--- a/src/chapters/chapter08/index.md
+++ b/src/chapters/chapter08/index.md
@@ -311,22 +311,27 @@ updates:
 
 ### Dependency reviewワークフロー
 
-#### PRでの依存関係チェック
+#### PRとmerge queueでの依存関係チェック
+
 ```yaml
 name: Dependency Review
 
-on: [pull_request]
+on:
+  pull_request:
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read
 
 jobs:
   dependency-review:
+    name: Dependency Review
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        
+
       - name: Dependency Review
         uses: actions/dependency-review-action@v4
         with:
@@ -334,6 +339,19 @@ jobs:
           deny-licenses: GPL-3.0, AGPL-3.0
           allow-ghsas: GHSA-xxxx-yyyy-zzzz
 ```
+
+merge queueは、queue内の変更を組み合わせたtemporary merge group commitに対して`checks_requested`を発行します。
+required checkにしたworkflowが`pull_request`だけを購読すると、このcommitに同じcheckが生成されずqueueが停止するため、`merge_group`でも同じ`Dependency Review` checkを実行します。
+required status checkの識別にはjob名が使われるため、`Dependency Review`というjob名を固定し、rulesetまたはbranch protectionではGitHubが返す正確なcheck名を選択してください。
+required checkにするworkflowへ`paths`または`paths-ignore` filterを設定すると、対象外のPRでworkflowがskipされ、checkがPendingのまま残るため設定しません。
+merge queueを使わないrepositoryでは`merge_group` eventが発火しないため、通常のPR検査を妨げません。
+全体のrequired check設計は[第13章のmerge queue節](../chapter13/)も参照してください。
+
+公式仕様:
+
+- Merge queue: <https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue>
+- `merge_group` event: <https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#merge_group>
+- Required status checksのtroubleshooting: <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks>
 
 ### ライセンスコンプライアンス
 


### PR DESCRIPTION
## 概要（必須）

- 変更内容: 第8章のDependency Review例に`merge_group: checks_requested`を追加し、PRとmerge queueの両方で同一required checkを生成する契約を明示しました。YAML AST契約チェッカーとnegative self-testをBook QAへ追加しました。

## 関連Issue/仕様（必須）

- Issue: Closes #246
- 仕様（要点）: `pull_request`と`merge_group`を併用し、安定したjob名、`contents: read`、path filterなし、Dependency Review action実行を検証します。

## 影響範囲（必須）

- 対象章/ページ: `/chapters/chapter08/`
- 影響: Dependency Review YAML例・運用説明・回帰防止QAの追記

## 受入基準（必須）

- [x] Issue の受入基準を満たす
- [x] 変更禁止領域に触れていない
- [x] 章参照・内部リンク・アンカーが壊れていない

## テスト/検証（必須）

- `mise exec node@24 -- npm ci`: PASS、audit 0
- `mise exec node@24 -- npm run test:light`: PASS（契約/self-test、metadata、lint、Jekyll buildを含む）
- `mise exec node@24 -- npm audit`: PASS、0 vulnerabilities
- `actionlint .github/workflows/book-qa.yml`: PASS
- `git -c core.whitespace=cr-at-eol diff --check`: PASS
- 独立correctness review: 初回2件を修正後、actionable finding 0
- GitHub公式仕様と`actions/dependency-review-action@v4`実装で`merge_group`対応を確認

## リスク/ロールバック（必須）

- リスク: 実repositoryでmerge queueを有効化する変更は対象外のため、実queue上のE2Eは未実施です。公式仕様、action実装、AST/self-testで静的に担保しています。
- ロールバック手順: 本PRのsquash merge commitをrevertします。

## Review 対応（必須）

- [x] review 本文・inline comment・suggestion を全件確認した
- [x] 修正した指摘には返信した
- [x] 修正しない指摘には理由を返信した（該当なし）
- [x] 未解決の review thread が 0 件である

## QA（必須）

- [x] Book QA: PASS
  - 実行URL: https://github.com/itdojp/github-workflow-book/actions/runs/29685814695
- [x] 必須 status checks が green である

## merge 後確認（原則必須）

- [ ] main の checks が green である
- [ ] Pagesと公開先のsmoke testを実施した
- [ ] 完了証跡をIssue #246に記録した

## Pages確認（原則必須）

- 確認URL: https://itdojp.github.io/github-workflow-book/chapters/chapter08/
- [ ] HTTP 200
- [ ] `merge_group` / `checks_requested` / `Dependency Review` markerを確認

## AI支援/エージェント利用の開示（任意）

- AI/エージェント利用: 有
- 利用範囲: 実装、公式仕様確認、独立レビュー、検証

## 補足

- Issue #248のCodeQL/Codex action hardeningは混在させていません。
